### PR TITLE
[nrf noup] Fix client view for PAKE operations

### DIFF
--- a/include/psa/crypto_struct.h
+++ b/include/psa/crypto_struct.h
@@ -502,8 +502,7 @@ struct psa_pake_operation_s {  /*!!OM*/
 #endif
 };
 
-/* This only zeroes out the first byte in the union, the rest is unspecified. */
-#define PSA_PAKE_OPERATION_INIT { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0 } }
+#define PSA_PAKE_OPERATION_INIT { }
 static inline struct psa_pake_operation_s psa_pake_operation_init(void)
 {
     const struct psa_pake_operation_s v = PSA_PAKE_OPERATION_INIT;
@@ -533,7 +532,7 @@ struct psa_sign_hash_interruptible_operation_s {
 #endif
 };
 
-#define PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT { 0,  0, 0, 0 }
+#define PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT { }
 
 static inline struct psa_sign_hash_interruptible_operation_s
 psa_sign_hash_interruptible_operation_init(void)


### PR DESCRIPTION
Fixes init-macros for PAKE operation and interruptable hash operations (not supported), to be compatible with client-view version of the structs.