### PR TITLE
PSA crypto client support

### DIFF
--- a/include/mbedtls/psa_util.h
+++ b/include/mbedtls/psa_util.h
@@ -122,5 +122,53 @@ extern mbedtls_psa_drbg_context_t *const mbedtls_psa_random_state;
 
 #endif /* !defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG) */
 
+/** \defgroup psa_tls_helpers TLS helper functions
+ * @{
+ */
+#if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
+#include <mbedtls/ecp.h>
+
+/** Convert an ECC curve identifier from the Mbed TLS encoding to PSA.
+ *
+ * \note This function is provided solely for the convenience of
+ *       Mbed TLS and may be removed at any time without notice.
+ *
+ * \param grpid         An Mbed TLS elliptic curve identifier
+ *                      (`MBEDTLS_ECP_DP_xxx`).
+ * \param[out] bits     On success, the bit size of the curve.
+ *
+ * \return              The corresponding PSA elliptic curve identifier
+ *                      (`PSA_ECC_FAMILY_xxx`).
+ * \return              \c 0 on failure (\p grpid is not recognized).
+ */
+psa_ecc_family_t mbedtls_ecc_group_to_psa(mbedtls_ecp_group_id grpid,
+                                          size_t *bits);
+
+/** Convert an ECC curve identifier from the PSA encoding to Mbed TLS.
+ *
+ * \note This function is provided solely for the convenience of
+ *       Mbed TLS and may be removed at any time without notice.
+ *
+ * \param curve         A PSA elliptic curve identifier
+ *                      (`PSA_ECC_FAMILY_xxx`).
+ * \param bits          The bit-length of a private key on \p curve.
+ * \param bits_is_sloppy If true, \p bits may be the bit-length rounded up
+ *                      to the nearest multiple of 8. This allows the caller
+ *                      to infer the exact curve from the length of a key
+ *                      which is supplied as a byte string.
+ *
+ * \return              The corresponding Mbed TLS elliptic curve identifier
+ *                      (`MBEDTLS_ECP_DP_xxx`).
+ * \return              #MBEDTLS_ECP_DP_NONE if \c curve is not recognized.
+ * \return              #MBEDTLS_ECP_DP_NONE if \p bits is not
+ *                      correct for \p curve.
+ */
+mbedtls_ecp_group_id mbedtls_ecc_group_of_psa(psa_ecc_family_t curve,
+                                              size_t bits,
+                                              int bits_is_sloppy);
+#endif /* PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY */
+
+/**@}*/
+
 #endif /* MBEDTLS_PSA_CRYPTO_C */
 #endif /* MBEDTLS_PSA_UTIL_H */

--- a/include/mbedtls/psa_util.h
+++ b/include/mbedtls/psa_util.h
@@ -30,7 +30,7 @@
 
 #include "mbedtls/build_info.h"
 
-#if defined(MBEDTLS_PSA_CRYPTO_C)
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 
 /* Expose whatever RNG the PSA subsystem uses to applications using the
  * mbedtls_xxx API. The declarations and definitions here need to be

--- a/library/psa_util_internal.h
+++ b/library/psa_util_internal.h
@@ -28,7 +28,7 @@
 
 #include "psa/crypto.h"
 
-#if defined(MBEDTLS_PSA_CRYPTO_C)
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 
 /*************************************************************************
  * FFDH


### PR DESCRIPTION
This includes a few noup patches to ensure Oberon PSA core can be used as a single source for PSA Crypto APIs 

The addition is made under the assumption that Oberon PSA core is preferred in the include order and that psa_util APIs are required to be in sync with what TLS/DTLS and X.509 expects with regards to type conversions (PSA <=> legacy)

This pull-request also enforces MBEDTLS_PSA_CRYPTO_CLIENT support which is used by nRF54H20 in a "core-less" build

The changes should be reverted with coming versions of Oberon PSA core
