### PR TITLE
[nrf noup] Add nRF54L15 support for legacy and PSA

### DIFF
--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -32,7 +32,14 @@
 #define MBEDTLS_PSA_CRYPTO_STORAGE_C  // Needed for supporting ITS
 #define PSA_ACCEL_GENERATE_RANDOM     // Kconfigs for PSA_NEED_* not used so manually enable it RNG
 #define PSA_ACCEL_GET_ENTROPY
+
+#ifdef CONFIG_NRF_CC3XX_PLATFORM
 #define PSA_NEED_CC3XX_CTR_DRBG_DRIVER
+#elif defined(CONFIG_NRF_SECURITY_LEGACY_AND_PSA) && defined(CONFIG_SOC_SERIES_NRF54LX)
+#define PSA_CRYPTO_DRIVER_CRACEN // Needed to include the cracen_psa.h
+#define PSA_NEED_CRACEN_CTR_DRBG_DRIVER
+#endif
+
 #include "oberon_config.h"            // The PSA_NEED symbols used from this file when not using Kconfigs
 #endif
 

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -762,7 +762,10 @@ psa_status_t psa_destroy_key(mbedtls_svc_key_id_t key)
 #if defined(MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS)
     if (psa_key_id_is_builtin(MBEDTLS_SVC_KEY_ID_GET_KEY_ID(slot->attr.id))) {
         psa_key_attributes_t attributes = {.core = slot->attr};
-        psa_driver_wrapper_destroy_builtin_key(&attributes);
+        status = psa_driver_wrapper_destroy_builtin_key(&attributes);
+        if (overall_status == PSA_SUCCESS) {
+            overall_status = status;
+        }
     }
 #endif /* defined(MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS) */
 

--- a/oberon/drivers/oberon_key_derivation.c
+++ b/oberon/drivers/oberon_key_derivation.c
@@ -22,7 +22,7 @@ static const uint8_t zero[PSA_HASH_MAX_SIZE] = { 0 };
 
 
 #if defined(PSA_NEED_OBERON_HKDF) || defined(PSA_NEED_OBERON_PBKDF2_HMAC) || defined(PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128) || \
-    defined(PSA_NEED_OBERON_SP800_108_COUNTER_HMAC) || defined(PSA_NEED_OBERON_SP800_108_COUNTER_CMAC)
+    defined(PSA_NEED_OBERON_SP800_108_COUNTER_HMAC) || defined(PSA_NEED_OBERON_SP800_108_COUNTER_CMAC) ||  defined(PSA_NEED_OBERON_TLS12_PRF) || defined(PSA_NEED_OBERON_TLS12_PSK_TO_MS)
 static psa_status_t oberon_setup_mac(
     oberon_key_derivation_operation_t *operation,
     const uint8_t *key, size_t key_length)


### PR DESCRIPTION
Add experimental support for legacy and PSA
APIs at the same time.

This commit exist because some protocols use
PSA APIs and some others still use the mbedTLS
legacy APIs for crypto. When all the protocols
(Bluetooth, WIFI, etc) port their code to use
PSA APIs we can remove this.