### PR TITLE
[nrf toup] fix unused variable warning

### DIFF
--- a/oberon/drivers/oberon_ec_keys.c
+++ b/oberon/drivers/oberon_ec_keys.c
@@ -70,7 +70,7 @@ psa_status_t oberon_export_ec_public_key(
     uint8_t *data, size_t data_size, size_t *data_length)
 {
     int res = 1;
-    size_t bits = psa_get_key_bits(attributes);
+    __attribute__((unused)) size_t bits = psa_get_key_bits(attributes);
     psa_key_type_t type = psa_get_key_type(attributes);
 
     if (PSA_KEY_TYPE_IS_PUBLIC_KEY(type)) {


### PR DESCRIPTION
Fix an unused variable warning that happens when building with the LLVM toolchain.
Adding the `unused` attribute to the variable to mark it as potentially unused is the simplest as it's used in different `#ifdef` scenarios.

This should be communicated to Oberon and fixed upstream.