### PR TITLE
[nrf toup] fix unused function warning

### DIFF
--- a/oberon/drivers/oberon_ecdsa.c
+++ b/oberon/drivers/oberon_ecdsa.c
@@ -40,7 +40,7 @@
 #endif /* PSA_NEED_OBERON_ED448PH */
 
 
-#ifdef PSA_NEED_OBERON_ECDSA_SIGN
+#if defined(PSA_NEED_OBERON_ECDSA_RANDOMIZED) || defined(PSA_NEED_OBERON_ECDSA_DETERMINISTIC)
 static int ecdsa_sign_hash(
     const uint8_t *key, size_t key_length,
     const uint8_t *hash,
@@ -79,7 +79,7 @@ static int ecdsa_sign_hash(
 
     return res;
 }
-#endif /* PSA_NEED_OBERON_ECDSA_SIGN */
+#endif /* PSA_NEED_OBERON_ECDSA_RANDOMIZED || PSA_NEED_OBERON_ECDSA_DETERMINISTIC */
 
 #ifdef PSA_NEED_OBERON_ECDSA_DETERMINISTIC
 /* hmac = HMAC_key(v || tag || sk || ext_hash) */


### PR DESCRIPTION
Fix unused function warning for ecdsa_sign_hash() by guarding it with the same conditions as those under which the function is used.