### PR TITLE
[nrf toup] drivers: Align RSA OAEP with the Cracen driver

### DIFF
--- a/oberon/drivers/oberon_rsa.c
+++ b/oberon/drivers/oberon_rsa.c
@@ -455,11 +455,11 @@ static psa_status_t eme_oaep_encode(
 
     if (m_len > em_len - 2 * hash_len - 2) return PSA_ERROR_INVALID_ARGUMENT;
 
+    memset(em, 0, em_len);
     status = psa_generate_random(seed, hash_len);
     if (status) return status;
 
     // db = lhash : {0} : 1 : m
-    memset(em, 0, em_len);
     memset(&hash_op, 0, sizeof hash_op);
     status = psa_driver_wrapper_hash_setup(&hash_op, hash_alg);
     if (status) goto exit;


### PR DESCRIPTION
Oberon was informed and will follow this methodology in the next release.