### PR TITLE
[nrf noup] library: fix psa_destroy_key

### DIFF
--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -853,7 +853,11 @@ psa_status_t psa_destroy_key(mbedtls_svc_key_id_t key)
     }
 
 #if defined(MBEDTLS_PSA_CRYPTO_STORAGE_C)
-    if (!PSA_KEY_LIFETIME_IS_VOLATILE(slot->attr.lifetime)) {
+    if (!PSA_KEY_LIFETIME_IS_VOLATILE(slot->attr.lifetime)
+#if defined(MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS)
+    && !psa_key_id_is_builtin(MBEDTLS_SVC_KEY_ID_GET_KEY_ID(slot->attr.id))
+#endif
+    ) {
         /* Destroy the copy of the persistent key from storage.
          * The slot will still hold a copy of the key until the last reader
          * unregisters. */


### PR DESCRIPTION
Attempt to destroy builtin key led to the `psa_destroy_persistent_key()` call without calling `psa_save_persistent_key()` prior to that.
It may also be the reason for the ITS error related to the 30-bit limit of the `psa_key_id_t` size since psa_driver_wrapper may require 32-bit key ID.