### PR TITLE
[nrf toup] don't try to find volatile/builtin keys from wrong sources

### DIFF
--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -685,6 +685,10 @@ static psa_status_t psa_load_persistent_key_into_slot(psa_key_slot_t *slot)
     uint8_t *key_data = NULL;
     size_t key_data_length = 0;
 
+    if (!psa_is_valid_key_id(slot->attr.id, 0)) {
+        return PSA_ERROR_DOES_NOT_EXIST;
+    }
+
 #if defined(MBEDTLS_PSA_STATIC_KEY_SLOTS)  /* !!OM */
     key_data = slot->key.data;
     status = psa_load_persistent_key_static(&slot->attr,


### PR DESCRIPTION
When not finding a given key in memory, the implementation would try to find it from the persistent keys regardless of the actual key type (volatile/builtin/persistent).

Don't try to find inexistent volatile/builtin keys from persistent ones.

In addition to the calls being superflous, the problem that was happening here is that the ITS implementation (Secure Storage subsystem) returns `PSA_ERROR_INVALID_ARGUMENT` because the ID is not in the persistent key range, and because it doesn't return `PSA_ERROR_DOES_NOT_EXIST` then the wrong error code is propagated back to the caller.

`toup` as the issue has been communicated to Mbed TLS and should be fixed there.
See:
- https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/488
- https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/492
