### PR TITLE
[nrf noup] drivers: key_derivation: Fix ifdefs for WPA3-SAE

### DIFF
--- a/oberon/drivers/oberon_key_derivation.c
+++ b/oberon/drivers/oberon_key_derivation.c
@@ -23,7 +23,7 @@ static const uint8_t zero[PSA_HASH_MAX_SIZE] = { 0 };
 
 #if defined(PSA_NEED_OBERON_HKDF) || defined(PSA_NEED_OBERON_PBKDF2_HMAC) || defined(PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128) || \
     defined(PSA_NEED_OBERON_SP800_108_COUNTER_HMAC) || defined(PSA_NEED_OBERON_SP800_108_COUNTER_CMAC) || \
-    defined(PSA_NEED_OBERON_TLS12_PRF) || defined(PSA_NEED_OBERON_TLS12_PSK_TO_MS)
+    defined(PSA_NEED_OBERON_TLS12_PRF) || defined(PSA_NEED_OBERON_TLS12_PSK_TO_MS) || defined(PSA_NEED_OBERON_WPA3_SAE_H2E)
 static psa_status_t oberon_setup_mac(
     oberon_key_derivation_operation_t *operation,
     const uint8_t *key, size_t key_length)
@@ -226,7 +226,7 @@ psa_status_t oberon_key_derivation_input_bytes(
                 status = oberon_setup_mac(operation, data, data_length);
                 if (status) goto exit;
                 operation->salt_length = (uint16_t)data_length;
-#endif /* PSA_NEED_OBERON_HKDF || PSA_NEED_OBERON_HKDF_EXTRACT */
+#endif /* PSA_NEED_OBERON_HKDF || PSA_NEED_OBERON_HKDF_EXTRACT || PSA_NEED_OBERON_WPA3_SAE_H2E */
 #ifdef PSA_NEED_OBERON_SRP_PASSWORD_HASH
             } else if (operation->alg == OBERON_SRP_PASSWORD_HASH_ALG) {
                 status = psa_driver_wrapper_hash_finish(&operation->hash_op, operation->data, sizeof operation->data, &length);
@@ -360,7 +360,7 @@ psa_status_t oberon_key_derivation_input_bytes(
             return PSA_SUCCESS;
         }
 #endif /* PSA_NEED_OBERON_HKDF || PSA_NEED_OBERON_HKDF_EXTRACT || PSA_NEED_OBERON_HKDF_EXPAND ||
-          PSA_NEED_OBERON_SRP_PASSWORD_HASH || PSA_NEED_OBERON_WPA3_SAE_PT */
+          PSA_NEED_OBERON_SRP_PASSWORD_HASH || PSA_NEED_OBERON_WPA3_SAE_H2E */
 
 #if defined(PSA_NEED_OBERON_PBKDF2_HMAC) || defined(PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128) || \
     defined(PSA_NEED_OBERON_SRP_PASSWORD_HASH) || defined(PSA_NEED_OBERON_WPA3_SAE_H2E)
@@ -475,7 +475,8 @@ psa_status_t oberon_key_derivation_input_bytes(
     }
 
 #if defined(PSA_NEED_OBERON_HKDF) || defined(PSA_NEED_OBERON_HKDF_EXTRACT) || \
-    defined(PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128) || defined(PSA_NEED_OBERON_SRP_PASSWORD_HASH)
+    defined(PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128) || defined(PSA_NEED_OBERON_SRP_PASSWORD_HASH) || \
+    defined(PSA_NEED_OBERON_WPA3_SAE_H2E)
 exit:
 #ifdef PSA_NEED_OBERON_SRP_PASSWORD_HASH
     if (operation->alg == OBERON_PBKDF2_HMAC_ALG) {
@@ -712,7 +713,8 @@ psa_status_t oberon_key_derivation_output_bytes(
 #if defined(PSA_NEED_OBERON_HKDF) || defined(PSA_NEED_OBERON_HKDF_EXPAND) || \
     defined(PSA_NEED_OBERON_PBKDF2_HMAC) || defined(PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128) || \
     defined(PSA_NEED_OBERON_TLS12_PRF) || defined(PSA_NEED_OBERON_TLS12_PSK_TO_MS) || \
-    defined(PSA_NEED_OBERON_SP800_108_COUNTER_HMAC) || defined(PSA_NEED_OBERON_SP800_108_COUNTER_CMAC)
+    defined(PSA_NEED_OBERON_SP800_108_COUNTER_HMAC) || defined(PSA_NEED_OBERON_SP800_108_COUNTER_CMAC) || \
+    defined(PSA_NEED_OBERON_WPA3_SAE_H2E)
 exit:
     psa_driver_wrapper_mac_abort(&operation->mac_op);
     return status;


### PR DESCRIPTION
Fixes build issues due to the missing checks for
PSA_NEED_OBERON_WPA3_SAE_H2E macro.

This change is already taken in and will be
a part of the future version of Oberon PSA Crypto.