### PR TITLE
[nrf noup] Fix for unexpected key length returned by AES-KWP

### DIFF
--- a/oberon/drivers/oberon_key_wrap.c
+++ b/oberon/drivers/oberon_key_wrap.c
@@ -205,7 +205,7 @@ psa_status_t oberon_unwrap_key(
     psa_status_t status;
 #endif /* PSA_NEED_OBERON_AES_KW || PSA_NEED_OBERON_AES_KWP */
 #ifdef PSA_NEED_OBERON_AES_KWP
-    size_t len, pad_len;
+    size_t len, pad_len, length;
 #endif /* PSA_NEED_OBERON_AES_KWP */
 
     switch (alg) {
@@ -261,7 +261,7 @@ psa_status_t oberon_unwrap_key(
         if (status != PSA_SUCCESS) goto exit;
 
         if (n == 1) {
-            status = psa_driver_wrapper_cipher_update(&cipher_op, data, data_length, a, 16, key_length);
+            status = psa_driver_wrapper_cipher_update(&cipher_op, data, data_length, a, 16, &length);
             if (status != PSA_SUCCESS) goto exit;
             memcpy(key, a + 8, 8);
         } else {


### PR DESCRIPTION
Software driver returned unexpected key length for some error cases. This led to a problem of clearing key slot afterwards.

This is reported to Oberon and will be fixed in the next release.