### PR TITLE
[nrf toup] Fix for empty static key slot buffer when HMAC is used

### DIFF
--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -49,6 +49,16 @@ extern "C" {
 #define MBEDTLS_PSA_STATIC_KEY_SLOT_BUFFER_SIZE  \
     ((PSA_EXPORT_KEY_PAIR_OR_PUBLIC_MAX_SIZE > PSA_CIPHER_MAX_KEY_LENGTH) ? \
      PSA_EXPORT_KEY_PAIR_OR_PUBLIC_MAX_SIZE : PSA_CIPHER_MAX_KEY_LENGTH)
+
+/* For HMAC, it's typical but not mandatory to use a key size that is equal to
+ * the hash size. */
+#if defined(PSA_WANT_ALG_HMAC)
+#if PSA_HASH_MAX_SIZE > MBEDTLS_PSA_STATIC_KEY_SLOT_BUFFER_SIZE
+#undef MBEDTLS_PSA_STATIC_KEY_SLOT_BUFFER_SIZE
+#define MBEDTLS_PSA_STATIC_KEY_SLOT_BUFFER_SIZE PSA_HASH_MAX_SIZE
+#endif
+#endif /* PSA_WANT_ALG_HMAC */
+
 #endif /* !MBEDTLS_PSA_STATIC_KEY_SLOT_BUFFER_SIZE*/
 
 /** \addtogroup attributes


### PR DESCRIPTION
When using an HMAC algorithm `MBEDTLS_PSA_STATIC_KEY_SLOT_BUFFER_SIZE` is set to 1 since `PSA_HASH_MAX_SIZE` was not taken into account, causing `PSA_ERROR_NOT_SUPPORTED` error when trying to allocate buffer to slot.

This commit fixes the issue by setting
`MBEDTLS_PSA_STATIC_KEY_SLOT_BUFFER_SIZE` to `PSA_HASH_MAX_SIZE` when HMAC is needed, similarly to Mbed TLS.

[nrf toup] since this fix was sent to Oberon and will be included in the next release.