### PR TITLE
update to v2.0.0

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -1,0 +1,5 @@
+"CI-crypto-test":
+  - "**/*"
+
+"CI-tfm-test":
+  - "**/*"

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -1,0 +1,11 @@
+name: Lint yaml files
+
+on:
+  pull_request:
+
+jobs:
+  lint_yaml:
+    runs-on: ubuntu-24.04
+    name: Execute yamllint
+    steps:
+      - uses: nrfconnect/action-yamllint@main

--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -866,7 +866,11 @@ psa_status_t psa_destroy_key(mbedtls_svc_key_id_t key)
     }
 
 #if defined(MBEDTLS_PSA_CRYPTO_STORAGE_C)
-    if (!PSA_KEY_LIFETIME_IS_VOLATILE(slot->attr.lifetime)) {
+    if (!PSA_KEY_LIFETIME_IS_VOLATILE(slot->attr.lifetime)
+#if defined(MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS)
+    && !psa_key_id_is_builtin(MBEDTLS_SVC_KEY_ID_GET_KEY_ID(slot->attr.id))
+#endif
+    ) {
         /* Destroy the copy of the persistent key from storage.
          * The slot will still hold a copy of the key until the last reader
          * unregisters. */
@@ -877,6 +881,15 @@ psa_status_t psa_destroy_key(mbedtls_svc_key_id_t key)
 
     }
 #endif /* defined(MBEDTLS_PSA_CRYPTO_STORAGE_C) */
+
+#if defined(MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS)
+    if (psa_key_id_is_builtin(MBEDTLS_SVC_KEY_ID_GET_KEY_ID(slot->attr.id))) {
+        status = psa_driver_wrapper_destroy_builtin_key(&slot->attr);
+        if (overall_status == PSA_SUCCESS) {
+            overall_status = status;
+        }
+    }
+#endif /* defined(MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS) */
 
 exit:
     /* Unregister from reading the slot. If we are the last active reader
@@ -1162,7 +1175,8 @@ static psa_status_t psa_validate_key_attributes(const psa_key_attributes_t *attr
             return PSA_ERROR_INVALID_ARGUMENT;
         }
     } else {
-        if (!psa_key_id_is_user(MBEDTLS_SVC_KEY_ID_GET_KEY_ID(key))) {
+        if ((!psa_key_id_is_user(MBEDTLS_SVC_KEY_ID_GET_KEY_ID(key)) &&
+             !(PSA_KEY_ID_VENDOR_MIN <= MBEDTLS_SVC_KEY_ID_GET_KEY_ID(key)) && (MBEDTLS_SVC_KEY_ID_GET_KEY_ID(key) <= PSA_KEY_ID_VENDOR_MAX))) {
             return PSA_ERROR_INVALID_ARGUMENT;
         }
     }
@@ -1301,7 +1315,11 @@ static psa_status_t psa_finish_key_creation(
 #endif
 
 #if defined(MBEDTLS_PSA_CRYPTO_STORAGE_C)
-    if (!PSA_KEY_LIFETIME_IS_VOLATILE(slot->attr.lifetime)) {
+    if (!PSA_KEY_LIFETIME_IS_VOLATILE(slot->attr.lifetime)
+#if defined(MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS)
+    && !psa_key_id_is_builtin(MBEDTLS_SVC_KEY_ID_GET_KEY_ID(slot->attr.id))
+#endif
+    ) {
         /* Key material is saved in export representation in the slot, so
          * just pass the slot buffer for storage. */
         status = psa_save_persistent_key(&slot->attr,
@@ -5026,7 +5044,6 @@ psa_status_t psa_key_derivation_input_key(
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_status_t unlock_status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_key_slot_t *slot = NULL;
-    psa_key_attributes_t attributes;
 
     status = psa_get_and_lock_key_slot_with_policy(
         key, &slot, 0, operation->alg);
@@ -5048,12 +5065,8 @@ psa_status_t psa_key_derivation_input_key(
         operation->can_output_key = 1;
     }
 
-    attributes = (psa_key_attributes_t) {
-        .core = slot->attr
-    };
-
     status = psa_key_derivation_input_internal(operation,
-                                               step, &attributes,
+                                               step, &slot->attr,
                                                slot->key.data,
                                                slot->key.bytes);
 

--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -1384,6 +1384,129 @@ static psa_status_t psa_validate_optional_attributes(
     return PSA_SUCCESS;
 }
 
+static psa_status_t psa_validate_ecc_key_attr(const psa_key_attributes_t *attributes)
+{
+    psa_algorithm_t alg = psa_get_key_algorithm(attributes);
+    size_t key_bits_attr = psa_get_key_bits(attributes);
+    psa_key_type_t type = psa_get_key_type(attributes);
+
+    /* Without algorithm we can't evaluate more fields */
+    if (alg == PSA_ALG_NONE) {
+        return PSA_SUCCESS;
+    }
+
+    /* It is not mandatory to set the key bits field, so zero is valid*/
+    if (key_bits_attr == 0) {
+        return PSA_SUCCESS;
+    }
+
+    /* Check if the size matches the curve family */
+    switch (PSA_KEY_TYPE_ECC_GET_FAMILY(type)) {
+        case PSA_ECC_FAMILY_SECP_K1:
+            if (key_bits_attr != 192 && key_bits_attr != 225 && key_bits_attr != 256) {
+                return PSA_ERROR_INVALID_ARGUMENT;
+            }
+            break;
+        case PSA_ECC_FAMILY_SECP_R1:
+            if (key_bits_attr != 192 && key_bits_attr != 224 && key_bits_attr != 256 &&
+                key_bits_attr != 384 && key_bits_attr != 521) {
+                return PSA_ERROR_INVALID_ARGUMENT;
+            }
+            break;
+        case PSA_ECC_FAMILY_SECT_K1:
+            if (key_bits_attr != 233 && key_bits_attr != 239 && key_bits_attr != 283 &&
+                key_bits_attr != 409 && key_bits_attr != 571) {
+                return PSA_ERROR_INVALID_ARGUMENT;
+            }
+            break;
+        case PSA_ECC_FAMILY_SECT_R1:
+            if (key_bits_attr != 233 && key_bits_attr != 283 && key_bits_attr != 409 &&
+                key_bits_attr != 571) {
+                return PSA_ERROR_INVALID_ARGUMENT;
+            }
+            break;
+        case PSA_ECC_FAMILY_BRAINPOOL_P_R1:
+            if (key_bits_attr != 192 && key_bits_attr != 224 && key_bits_attr != 256 &&
+                key_bits_attr != 320 && key_bits_attr != 384 && key_bits_attr != 512) {
+                return PSA_ERROR_INVALID_ARGUMENT;
+            }
+            break;
+        case PSA_ECC_FAMILY_TWISTED_EDWARDS:
+        case PSA_ECC_FAMILY_MONTGOMERY:
+            if (key_bits_attr != 255 && key_bits_attr != 448) {
+                return PSA_ERROR_INVALID_ARGUMENT;
+            }
+            break;
+        default:
+            return PSA_ERROR_NOT_SUPPORTED;
+    }
+
+    return PSA_SUCCESS;
+}
+
+static psa_status_t psa_validate_ecc_key_data_length(const psa_key_attributes_t *attributes,
+                                                     size_t data_length)
+{
+    psa_algorithm_t alg = psa_get_key_algorithm(attributes);
+    psa_key_type_t type = psa_get_key_type(attributes);
+    size_t key_bits_attr = psa_get_key_bits(attributes);
+
+
+    /* Without  algorithm we can't evaluate more fields */
+    if (alg == PSA_ALG_NONE) {
+        return PSA_SUCCESS;
+    }
+
+        /* It is not mandatory to set the key bits field, so zero is valid */
+    if (key_bits_attr == 0) {
+        return PSA_SUCCESS;
+    }
+
+    /* Check if the size matches the curve family */
+    switch (PSA_KEY_TYPE_ECC_GET_FAMILY(type)) {
+        case PSA_ECC_FAMILY_SECP_R1:
+            /* secpr1p521 can be encoded in 65(first byte = 0) or 66 bytes therefore checking for
+             * 65 bytes is enough
+             */
+            if (key_bits_attr == 521) {
+                if (data_length < 65) {
+                    return PSA_ERROR_INVALID_ARGUMENT;
+                } else {
+                    return PSA_SUCCESS;
+                }
+            }
+            /* else we can do the same check than for all other curves */
+        case PSA_ECC_FAMILY_SECT_K1:
+        case PSA_ECC_FAMILY_SECT_R1:
+        case PSA_ECC_FAMILY_BRAINPOOL_P_R1:
+        case PSA_ECC_FAMILY_TWISTED_EDWARDS:
+        case PSA_ECC_FAMILY_MONTGOMERY:
+            if (data_length < PSA_BITS_TO_BYTES(key_bits_attr)){
+                return PSA_ERROR_INVALID_ARGUMENT;
+            }
+            break;
+        default:
+            break;
+    }
+
+    return PSA_SUCCESS;
+}
+
+static psa_status_t psa_ecc_key_zero_check(const uint8_t *data, size_t data_length)
+{
+    uint8_t zero = 0;
+
+    for (size_t i = 0; i < data_length; i++) {
+        zero |= data[i];
+    }
+
+    if (zero == 0) {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+
+    return PSA_SUCCESS;
+}
+
 psa_status_t psa_import_key(const psa_key_attributes_t *attributes,
                             const uint8_t *data,
                             size_t data_length,
@@ -1393,6 +1516,7 @@ psa_status_t psa_import_key(const psa_key_attributes_t *attributes,
     psa_key_slot_t *slot = NULL;
     size_t bits;
     size_t storage_size = data_length;
+    psa_key_type_t key_type = psa_get_key_type(attributes);
 
     *key = MBEDTLS_SVC_KEY_ID_INIT;
 
@@ -1406,6 +1530,22 @@ psa_status_t psa_import_key(const psa_key_attributes_t *attributes,
     /* Ensure that the bytes-to-bits conversion cannot overflow. */
     if (data_length > SIZE_MAX / 8) {
         return PSA_ERROR_NOT_SUPPORTED;
+    }
+
+    /* Check the ecc keys for plausibility */
+    if(PSA_KEY_TYPE_IS_ECC_KEY_PAIR(key_type) || PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(key_type)) {
+        status = psa_validate_ecc_key_attr(attributes);
+        if (status != PSA_SUCCESS) {
+            return status;
+        }
+        status = psa_validate_ecc_key_data_length(attributes, data_length);
+        if (status != PSA_SUCCESS) {
+            return status;
+        }
+        status = psa_ecc_key_zero_check(data, data_length);
+        if (status != PSA_SUCCESS) {
+            return status;
+        }
     }
 
     status = psa_start_key_creation(attributes, &slot);
@@ -6104,6 +6244,7 @@ psa_status_t psa_generate_key(const psa_key_attributes_t *attributes,
     psa_status_t status;
     psa_key_slot_t *slot = NULL;
     size_t key_buffer_size;
+    psa_key_type_t key_type = psa_get_key_type(attributes);
 
     *key = MBEDTLS_SVC_KEY_ID_INIT;
 
@@ -6117,6 +6258,15 @@ psa_status_t psa_generate_key(const psa_key_attributes_t *attributes,
     if (PSA_KEY_TYPE_IS_PUBLIC_KEY(attributes->type)) {
         return PSA_ERROR_INVALID_ARGUMENT;
     }
+
+    /* Check the ecc keys for plausibility */
+    if(PSA_KEY_TYPE_IS_ECC_KEY_PAIR(key_type) || PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(key_type)) {
+        status = psa_validate_ecc_key_attr(attributes);
+        if (status != PSA_SUCCESS) {
+            return status;
+        }
+    }
+
 
     status = psa_start_key_creation(attributes, &slot);
     if (status != PSA_SUCCESS) {

--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -6418,6 +6418,27 @@ psa_status_t psa_crypto_init(void)
         return PSA_SUCCESS;
     }
 
+    /* Init key slots */
+
+#if defined(MBEDTLS_THREADING_C)
+    PSA_THREADING_CHK_GOTO_EXIT(mbedtls_mutex_lock(&mbedtls_threading_psa_globaldata_mutex));
+#endif /* defined(MBEDTLS_THREADING_C) */
+
+    if (!(global_data.initialized & PSA_CRYPTO_SUBSYSTEM_KEY_SLOTS_INITIALIZED)) {
+        status = psa_initialize_key_slots();
+
+        /* Need to wipe keys even if initialization fails. */
+        global_data.initialized |= PSA_CRYPTO_SUBSYSTEM_KEY_SLOTS_INITIALIZED;
+    }
+
+#if defined(MBEDTLS_THREADING_C)
+    PSA_THREADING_CHK_GOTO_EXIT(mbedtls_mutex_unlock(
+        &mbedtls_threading_psa_globaldata_mutex));
+#endif /* defined(MBEDTLS_THREADING_C) */
+
+    if (status != PSA_SUCCESS) {
+        goto exit;
+    }
     /* Init drivers */
 
 #if defined(MBEDTLS_THREADING_C)
@@ -6430,28 +6451,6 @@ psa_status_t psa_crypto_init(void)
 
         /* Drivers need shutdown regardless of startup errors. */
         global_data.initialized |= PSA_CRYPTO_SUBSYSTEM_DRIVER_WRAPPERS_INITIALIZED;
-    }
-
-#if defined(MBEDTLS_THREADING_C)
-    PSA_THREADING_CHK_GOTO_EXIT(mbedtls_mutex_unlock(
-        &mbedtls_threading_psa_globaldata_mutex));
-#endif /* defined(MBEDTLS_THREADING_C) */
-
-    if (status != PSA_SUCCESS) {
-        goto exit;
-    }
-
-    /* Init key slots */
-
-#if defined(MBEDTLS_THREADING_C)
-    PSA_THREADING_CHK_GOTO_EXIT(mbedtls_mutex_lock(&mbedtls_threading_psa_globaldata_mutex));
-#endif /* defined(MBEDTLS_THREADING_C) */
-
-    if (!(global_data.initialized & PSA_CRYPTO_SUBSYSTEM_KEY_SLOTS_INITIALIZED)) {
-        status = psa_initialize_key_slots();
-
-        /* Need to wipe keys even if initialization fails. */
-        global_data.initialized |= PSA_CRYPTO_SUBSYSTEM_KEY_SLOTS_INITIALIZED;
     }
 
 #if defined(MBEDTLS_THREADING_C)

--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -1698,7 +1698,12 @@ psa_status_t psa_copy_key(mbedtls_svc_key_id_t source_key,
      * - For opaque keys this translates to an invocation of the drivers'
      *   copy_key entry point through the dispatch layer.
      * */
-    if (psa_key_lifetime_is_external(actual_attributes.lifetime)) {
+    if (psa_key_lifetime_is_external(actual_attributes.lifetime)
+#if defined(MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS) && defined(HALTIUM_XXAA)
+    /* NCSDK-36345: See if this change can be standardized for all platforms */
+    || psa_key_id_is_builtin(MBEDTLS_SVC_KEY_ID_GET_KEY_ID(target_slot->attr.id))
+#endif
+    ) {
         status = psa_driver_wrapper_get_key_buffer_size(&actual_attributes,
                                                         &storage_size);
         if (status != PSA_SUCCESS) {

--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -4737,6 +4737,7 @@ psa_status_t psa_key_derivation_setup(psa_key_derivation_operation_t *operation,
  * that the input was passed as a buffer rather than via a key object.
  */
 static int psa_key_derivation_check_input_type(
+    psa_algorithm_t alg,
     psa_key_derivation_step_t step,
     psa_key_type_t key_type)
 {
@@ -4752,6 +4753,9 @@ static int psa_key_derivation_check_input_type(
                 return PSA_SUCCESS;
             }
             if (key_type == PSA_KEY_TYPE_NONE) {
+                return PSA_SUCCESS;
+            }
+            if (key_type == PSA_KEY_TYPE_AES && alg == PSA_ALG_SP800_108_COUNTER_CMAC) {
                 return PSA_SUCCESS;
             }
             break;
@@ -4779,7 +4783,7 @@ static int psa_key_derivation_check_input_type(
 static psa_status_t psa_key_derivation_input_internal(
     psa_key_derivation_operation_t *operation,
     psa_key_derivation_step_t step,
-    psa_key_type_t key_type,
+    psa_key_attributes_t *attributes,
     const uint8_t *data,
     size_t data_length)
 {
@@ -4791,22 +4795,30 @@ static psa_status_t psa_key_derivation_input_internal(
         step == PSA_KEY_DERIVATION_INPUT_SECRET) {
         // key must be a block-cipher key
         // psa_key_derivation_input_bytes (key_type == PSA_KEY_TYPE_NONE) is not allowed
-        if ((key_type & ~0xFF) != PSA_KEY_TYPE_AES) {
+        if ((attributes->type & ~0xFF) != PSA_KEY_TYPE_AES) {
             status = PSA_ERROR_INVALID_ARGUMENT;
             goto exit;
         }
     } else if (PSA_ALG_IS_SP800_108_COUNTER_HMAC(operation->alg) &&
         step == PSA_KEY_DERIVATION_INPUT_SECRET &&
-        key_type == PSA_KEY_TYPE_HMAC) {
+        attributes->type == PSA_KEY_TYPE_HMAC) {
         // ok
     } else {
-        status = psa_key_derivation_check_input_type(step, key_type);
+        status = psa_key_derivation_check_input_type(operation->alg, step,
+            attributes ? attributes->type : PSA_KEY_TYPE_NONE);
         if (status != PSA_SUCCESS) {
             goto exit;
         }
     }
 
-    status = psa_driver_wrapper_key_derivation_input_bytes(operation, step, data, data_length);
+    if (attributes)
+    {
+        status = psa_driver_wrapper_key_derivation_input_key(operation, step, attributes, data, data_length);
+    }
+    else {
+        status = psa_driver_wrapper_key_derivation_input_bytes(operation, step, data, data_length);
+    }
+
     if (status != PSA_SUCCESS) goto exit;
 
     return PSA_SUCCESS;
@@ -4823,7 +4835,7 @@ psa_status_t psa_key_derivation_input_bytes(
     size_t data_length)
 {
     return psa_key_derivation_input_internal(operation, step,
-                                             PSA_KEY_TYPE_NONE,
+                                             NULL,
                                              data, data_length);
 }
 
@@ -4842,7 +4854,7 @@ psa_status_t psa_key_derivation_input_integer(
     status = psa_key_derivation_check_state(operation, step);
     if (status != PSA_SUCCESS) goto exit;
 
-    status = psa_key_derivation_check_input_type(step, PSA_KEY_TYPE_NONE);
+    status = psa_key_derivation_check_input_type(operation->alg, step, PSA_KEY_TYPE_NONE);
     if (status != PSA_SUCCESS) goto exit;
 
     if (PSA_ALG_IS_PBKDF2(operation->alg)) {
@@ -4874,6 +4886,7 @@ psa_status_t psa_key_derivation_input_key(
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_status_t unlock_status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_key_slot_t *slot = NULL;
+    psa_key_attributes_t attributes;
 
     status = psa_get_and_lock_key_slot_with_policy(
         key, &slot, 0, operation->alg);
@@ -4895,8 +4908,12 @@ psa_status_t psa_key_derivation_input_key(
         operation->can_output_key = 1;
     }
 
+    attributes = (psa_key_attributes_t) {
+        .core = slot->attr
+    };
+
     status = psa_key_derivation_input_internal(operation,
-                                               step, slot->attr.type,
+                                               step, &attributes,
                                                slot->key.data,
                                                slot->key.bytes);
 
@@ -4948,7 +4965,7 @@ static psa_status_t psa_key_agreement_internal(psa_key_derivation_operation_t *o
      * the shared secret. A shared secret is permitted wherever a key
      * of type DERIVE is permitted. */
     status = psa_key_derivation_input_internal(operation, step,
-                                               PSA_KEY_TYPE_DERIVE,
+                                               NULL,
                                                shared_secret,
                                                shared_secret_length);
 exit:

--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -34,6 +34,9 @@
 #include "mbedtls/threading.h"
 #include "threading_internal.h"
 
+#if !defined(MBEDTLS_PSA_STATIC_KEY_SLOTS)
+#include "mbedtls/platform.h"
+#endif
 
 #if defined(PSA_CRYPTO_DRIVER_TFM_BUILTIN_KEY_LOADER)
 #include "tfm_builtin_key_loader.h"

--- a/core/psa_crypto_slot_management.c
+++ b/core/psa_crypto_slot_management.c
@@ -916,7 +916,7 @@ psa_status_t psa_validate_key_persistence(psa_key_lifetime_t lifetime)
         return PSA_SUCCESS;
     } else {
         /* Persistent keys require storage support */
-#if defined(MBEDTLS_PSA_CRYPTO_STORAGE_C)
+#if defined(MBEDTLS_PSA_CRYPTO_STORAGE_C) || defined(MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS)
         if (PSA_KEY_LIFETIME_IS_READ_ONLY(lifetime)) {
             return PSA_ERROR_INVALID_ARGUMENT;
         } else {

--- a/core/psa_crypto_storage.c
+++ b/core/psa_crypto_storage.c
@@ -121,6 +121,11 @@ int psa_is_key_present_in_storage(const mbedtls_svc_key_id_t key)
  *
  * \retval #PSA_SUCCESS \emptydescription
  * \retval #PSA_ERROR_INSUFFICIENT_STORAGE \emptydescription
+ * \retval #PSA_ERROR_DATA_CORRUPT \emptydescription
+ * \retval #PSA_ERROR_DOES_NOT_EXIST \emptydescription
+ * \retval #PSA_ERROR_INVALID_ARGUMENT \emptydescription
+ * \retval #PSA_ERROR_NOT_PERMITTED \emptydescription
+ * \retval #PSA_ERROR_NOT_SUPPORTED \emptydescription
  * \retval #PSA_ERROR_ALREADY_EXISTS \emptydescription
  * \retval #PSA_ERROR_STORAGE_FAILURE \emptydescription
  * \retval #PSA_ERROR_DATA_INVALID \emptydescription
@@ -139,7 +144,7 @@ static psa_status_t psa_crypto_storage_store(const mbedtls_svc_key_id_t key,
 
     status = psa_its_set(data_identifier, (uint32_t) data_length, data, 0);
     if (status != PSA_SUCCESS) {
-        return PSA_ERROR_DATA_INVALID;
+        return status;
     }
 
     status = psa_its_get_info(data_identifier, &data_identifier_info);

--- a/core/tf_psa_crypto_platform_requirements.h
+++ b/core/tf_psa_crypto_platform_requirements.h
@@ -15,11 +15,6 @@
 #ifndef TF_PSA_CRYPTO_TF_PSA_CRYPTO_PLATFORM_REQUIREMENTS_H
 #define TF_PSA_CRYPTO_TF_PSA_CRYPTO_PLATFORM_REQUIREMENTS_H
 
-#ifndef __STDC_WANT_LIB_EXT1__
-/* Ask for the C11 gmtime_s() and memset_s() if available */
-#define __STDC_WANT_LIB_EXT1__ 1
-#endif
-
 #if !defined(_POSIX_C_SOURCE)
 /* For standards-compliant access to
  * clock_gettime(), gmtime_r(), ...

--- a/dispatch/psa_crypto_driver_wrappers.h
+++ b/dispatch/psa_crypto_driver_wrappers.h
@@ -11,6 +11,7 @@
 
 #include "psa/crypto.h"
 #include "psa/crypto_driver_common.h"
+#include "psa/crypto_types.h"
 
 /*
  * Initialization and termination functions
@@ -434,6 +435,12 @@ psa_status_t psa_driver_wrapper_key_derivation_set_capacity(
 psa_status_t psa_driver_wrapper_key_derivation_input_bytes(
     psa_key_derivation_operation_t *operation,
     psa_key_derivation_step_t step,
+    const uint8_t *data, size_t data_length);
+
+psa_status_t psa_driver_wrapper_key_derivation_input_key(
+    psa_key_derivation_operation_t *operation,
+    psa_key_derivation_step_t step,
+    psa_key_attributes_t *attributes,
     const uint8_t *data, size_t data_length);
 
 psa_status_t psa_driver_wrapper_key_derivation_input_integer(

--- a/dispatch/psa_crypto_driver_wrappers.h
+++ b/dispatch/psa_crypto_driver_wrappers.h
@@ -141,6 +141,9 @@ psa_status_t psa_driver_wrapper_derive_key(
     const uint8_t *input, size_t input_length,
     uint8_t *key_buffer, size_t key_buffer_size, size_t *key_buffer_length);
 
+psa_status_t psa_driver_wrapper_destroy_builtin_key(
+    const psa_key_attributes_t *attributes);
+
 /*
  * Cipher functions
  */

--- a/drivers/code_share.c
+++ b/drivers/code_share.c
@@ -1,0 +1,3 @@
+/* This is a deliberately empty file just to check whether the patch for enabling
+ * extensive crypto code sharing was already applied on the tf-psa-crypto library.
+ */

--- a/include/mbedtls/platform.h
+++ b/include/mbedtls/platform.h
@@ -65,12 +65,21 @@ extern "C" {
 #if !defined(MBEDTLS_PLATFORM_STD_FPRINTF)
 #define MBEDTLS_PLATFORM_STD_FPRINTF fprintf /**< The default \c fprintf function to use. */
 #endif
-#if !defined(MBEDTLS_PLATFORM_STD_CALLOC)
-#define MBEDTLS_PLATFORM_STD_CALLOC   calloc /**< The default \c calloc function to use. */
-#endif
-#if !defined(MBEDTLS_PLATFORM_STD_FREE)
-#define MBEDTLS_PLATFORM_STD_FREE       free /**< The default \c free function to use. */
-#endif
+
+/* We intentionally don't set MBEDTLS_PLATFORM_STD_CALLOC to 'calloc' and
+ * MBEDTLS_PLATFORM_STD_FREE to 'free' here.
+ * This would pull in stdlib heap usage such as the function `_sbrk'.
+ * When these are undefined platform.c will define empty stub functions
+ * which are replaced at initialization by mbedtls_memory_buffer_alloc_init()
+ * calling mbedtls_platform_set_calloc_free() to set alternative heap functions.
+ */
+// #if !defined(MBEDTLS_PLATFORM_STD_CALLOC)
+// #define MBEDTLS_PLATFORM_STD_CALLOC   calloc /**< The default \c calloc function to use. */
+// #endif
+// #if !defined(MBEDTLS_PLATFORM_STD_FREE)
+// #define MBEDTLS_PLATFORM_STD_FREE       free /**< The default \c free function to use. */
+// #endif
+
 #if !defined(MBEDTLS_PLATFORM_STD_SETBUF)
 #define MBEDTLS_PLATFORM_STD_SETBUF   setbuf /**< The default \c setbuf function to use. */
 #endif

--- a/include/psa/crypto_compat.h
+++ b/include/psa/crypto_compat.h
@@ -36,6 +36,17 @@ extern "C" {
  */
 int psa_can_do_hash(psa_algorithm_t hash_alg);
 
+/* This function is not a TF-PSA-Crypto API and may be removed without notice.
+ *
+ * Tell if the given cipher is supported by PSA.
+ *
+ * \param key_type    The key type.
+ * \param cipher_alg  The cipher algorithm.
+ *
+ * \return 1 if the PSA can handle \p cipher_alg, 0 otherwise.
+ */
+int psa_can_do_cipher(psa_key_type_t key_type, psa_algorithm_t cipher_alg);
+
 /* This defition is required to provide compatibility with the PSA arch
  * tests. Without it building the tests will fail. To remove it we would
  * need to change the tests to remove all references to this symbol.

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -247,11 +247,29 @@ void mbedtls_psa_get_stats(mbedtls_psa_stats_t *stats);
     (PSA_ALG_IS_DSA(alg) && !PSA_ALG_DSA_IS_DETERMINISTIC(alg))
 
 
+#ifdef PSA_WANT_ALG_LMS
+/* Note: TF-M supports LMS as a vendor extension and requires some LMS/HMS specific
+ * values to be available to properly override the PSA_ALG_IS_VENDOR_HASH_AND_SIGN
+ * macro.
+ */
+#include "crypto_values_lms.h"
+#endif
+
+
+#undef PSA_ALG_IS_VENDOR_HASH_AND_SIGN
+#ifdef PSA_WANT_ALG_LMS
+/* This overrides the default PSA_ALG_IS_VENDOR_HASH_AND_SIGN in crypto_values.h */
+#define PSA_ALG_IS_VENDOR_HASH_AND_SIGN(alg) ( \
+    (PSA_ALG_IS_LMS(alg)) || \
+    (PSA_ALG_IS_HSS(alg)) || \
+    (PSA_ALG_IS_DSA(alg)) \
+    )
+#else
 /* We need to expand the sample definition of this macro from
  * the API definition. */
-#undef PSA_ALG_IS_VENDOR_HASH_AND_SIGN
 #define PSA_ALG_IS_VENDOR_HASH_AND_SIGN(alg)    \
     PSA_ALG_IS_DSA(alg)
+#endif /* PSA_WANT_ALG_LMS */
 
 /**@}*/
 

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -470,7 +470,7 @@ psa_status_t psa_random_set_prediction_resistance(unsigned enabled);
  * This value is part of the library's API since changing it would invalidate
  * the values of built-in key identifiers in applications.
  */
-#define MBEDTLS_PSA_KEY_ID_BUILTIN_MIN          ((psa_key_id_t) 0x7fff0000)
+#define MBEDTLS_PSA_KEY_ID_BUILTIN_MIN          ((psa_key_id_t) 0x40001000)
 
 /** The maximum value for a key identifier that is built into the
  * implementation.

--- a/include/psa/crypto_sizes.h
+++ b/include/psa/crypto_sizes.h
@@ -274,6 +274,7 @@
  * PSA_KEY_EXPORT_ECC_KEY_PAIR_MAX_SIZE(PSA_VENDOR_ECC_MAX_CURVE_BITS)
  * work correctly when ED448 is the largest curve.
  * These terms are frequently used at various places in PSA and mbedTLS. */
+#ifndef PSA_VENDOR_ECC_MAX_CURVE_BITS
 #if defined(PSA_WANT_ECC_SECP_R1_521)
 #define PSA_VENDOR_ECC_MAX_CURVE_BITS 521u
 #elif defined(PSA_WANT_ECC_BRAINPOOL_P_R1_512)
@@ -306,6 +307,7 @@
 #define PSA_VENDOR_ECC_MAX_CURVE_BITS 192u
 #else
 #define PSA_VENDOR_ECC_MAX_CURVE_BITS 1u
+#endif
 #endif
 
 /* The maximum size of an ML-DSA public key on this implementation, in bytes.

--- a/include/psa/crypto_struct.h
+++ b/include/psa/crypto_struct.h
@@ -312,6 +312,10 @@ typedef uint16_t psa_key_bits_t;
  * conditionals. */
 #define PSA_MAX_KEY_BITS 0xfff8
 
+/* Reserved key attribute init used when MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER *
+ * Is enabled (changes the parameters of the initalization) */
+#define MBEDTLS_KEY_ATTRIBUTE_RESERVED_INIT (int32_t) 0
+
 struct psa_key_attributes_s {
     psa_key_type_t MBEDTLS_PRIVATE(type);
     psa_key_bits_t MBEDTLS_PRIVATE(bits);
@@ -329,12 +333,28 @@ struct psa_key_attributes_s {
      * struct
      */
     mbedtls_svc_key_id_t MBEDTLS_PRIVATE(id);
+#if !defined(MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER)
+    /* Reserved field added to enforce ABI-compliance */
+    int32_t  MBEDTLS_PRIVATE(reserved);
+#endif /* !MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER */
 };
 
+/* There is a difference in the initialization of the psa_key_attributes_s 
+ * dependent on MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER being set or not,
+ * ensuring we can have ABI compliance in this structure type.
+ */
+#if defined(MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER)
 #define PSA_KEY_ATTRIBUTES_INIT { PSA_KEY_TYPE_NONE, 0,            \
                                   PSA_KEY_LIFETIME_VOLATILE,       \
                                   PSA_KEY_POLICY_INIT,             \
                                   MBEDTLS_SVC_KEY_ID_INIT }
+#else
+#define PSA_KEY_ATTRIBUTES_INIT { PSA_KEY_TYPE_NONE, 0,                \
+                                  PSA_KEY_LIFETIME_VOLATILE,           \
+                                  PSA_KEY_POLICY_INIT,                 \
+                                  MBEDTLS_SVC_KEY_ID_INIT,             \
+                                  MBEDTLS_KEY_ATTRIBUTE_RESERVED_INIT}
+#endif /* MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER */
 
 static inline struct psa_key_attributes_s psa_key_attributes_init(void)
 {

--- a/include/psa/crypto_struct.h
+++ b/include/psa/crypto_struct.h
@@ -54,6 +54,8 @@
 #define PSA_CRYPTO_STRUCT_H
 #include "mbedtls/private_access.h"
 
+#include <inttypes.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -78,11 +80,9 @@ struct psa_hash_operation_s {
     psa_driver_hash_context_t MBEDTLS_PRIVATE(ctx);
 #endif
 };
-#if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_HASH_OPERATION_INIT { 0 }
-#else
-#define PSA_HASH_OPERATION_INIT { 0, { 0 } }
-#endif
+
+#define PSA_HASH_OPERATION_INIT { }
+
 static inline struct psa_hash_operation_s psa_hash_operation_init(void)
 {
     const struct psa_hash_operation_s v = PSA_HASH_OPERATION_INIT;
@@ -142,11 +142,9 @@ struct psa_cipher_operation_s {
 #endif
 };
 
-#if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_CIPHER_OPERATION_INIT { 0 }
-#else
-#define PSA_CIPHER_OPERATION_INIT { 0, 0, 0, 0, { 0 } }
-#endif
+
+#define PSA_CIPHER_OPERATION_INIT { }
+
 static inline struct psa_cipher_operation_s psa_cipher_operation_init(void)
 {
     const struct psa_cipher_operation_s v = PSA_CIPHER_OPERATION_INIT;
@@ -174,11 +172,8 @@ struct psa_mac_operation_s {
 #endif
 };
 
-#if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_MAC_OPERATION_INIT { 0 }
-#else
-#define PSA_MAC_OPERATION_INIT { 0, 0, 0, { 0 } }
-#endif
+#define PSA_MAC_OPERATION_INIT { }
+
 static inline struct psa_mac_operation_s psa_mac_operation_init(void)
 {
     const struct psa_mac_operation_s v = PSA_MAC_OPERATION_INIT;
@@ -213,11 +208,9 @@ struct psa_aead_operation_s {
 #endif
 };
 
-#if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_AEAD_OPERATION_INIT { 0 }
-#else
-#define PSA_AEAD_OPERATION_INIT { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0 } }
-#endif
+
+#define PSA_AEAD_OPERATION_INIT { }
+
 static inline struct psa_aead_operation_s psa_aead_operation_init(void)
 {
     const struct psa_aead_operation_s v = PSA_AEAD_OPERATION_INIT;
@@ -258,12 +251,9 @@ struct psa_key_derivation_s {  /*!!OM*/
 #endif
 };
 
-#if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_KEY_DERIVATION_OPERATION_INIT { 0 }
-#else
-/* This only zeroes out the first byte in the union, the rest is unspecified. */
-#define PSA_KEY_DERIVATION_OPERATION_INIT { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0 } }
-#endif
+
+#define PSA_KEY_DERIVATION_OPERATION_INIT {  }
+
 static inline struct psa_key_derivation_s psa_key_derivation_operation_init(
     void)
 {
@@ -514,12 +504,9 @@ struct psa_pake_operation_s {  /*!!OM*/
 #endif
 };
 
-#if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_PAKE_OPERATION_INIT { 0 }
-#else
-/* This only zeroes out the first byte in the union, the rest is unspecified. */
-#define PSA_PAKE_OPERATION_INIT { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0 } }
-#endif
+
+#define PSA_PAKE_OPERATION_INIT { }
+
 static inline struct psa_pake_operation_s psa_pake_operation_init(void)
 {
     const struct psa_pake_operation_s v = PSA_PAKE_OPERATION_INIT;
@@ -550,11 +537,7 @@ struct psa_sign_hash_interruptible_operation_s {
 #endif
 };
 
-#if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT { 0 }
-#else
-#define PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT { 0, { 0 }, 0, 0 }
-#endif
+#define PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT { }
 
 static inline struct psa_sign_hash_interruptible_operation_s
 psa_sign_hash_interruptible_operation_init(void)
@@ -588,11 +571,8 @@ struct psa_verify_hash_interruptible_operation_s {
 #endif
 };
 
-#if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_VERIFY_HASH_INTERRUPTIBLE_OPERATION_INIT { 0 }
-#else
-#define PSA_VERIFY_HASH_INTERRUPTIBLE_OPERATION_INIT { 0, { 0 }, 0, 0 }
-#endif
+
+#define PSA_VERIFY_HASH_INTERRUPTIBLE_OPERATION_INIT { }
 
 static inline struct psa_verify_hash_interruptible_operation_s
 psa_verify_hash_interruptible_operation_init(void)

--- a/legacy_sub/include/mbedtls/private/error.h
+++ b/legacy_sub/include/mbedtls/private/error.h
@@ -10,7 +10,7 @@
 #ifndef MBEDTLS_ERROR_H
 #define MBEDTLS_ERROR_H
 
-#include "mbedtls/build_info.h"
+#include "tf-psa-crypto/build_info.h"
 
 #include <stddef.h>
 

--- a/legacy_sub/src/block_cipher_internal.h
+++ b/legacy_sub/src/block_cipher_internal.h
@@ -1,0 +1,99 @@
+/**
+ * \file block_cipher_internal.h
+ *
+ * \brief Lightweight abstraction layer for block ciphers with 128 bit blocks,
+ * for use by the GCM and CCM modules.
+ */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+#ifndef TF_PSA_CRYPTO_BLOCK_CIPHER_INTERNAL_H
+#define TF_PSA_CRYPTO_BLOCK_CIPHER_INTERNAL_H
+
+#include "tf-psa-crypto/build_info.h"
+
+#include "mbedtls/private/cipher.h"
+
+#include "mbedtls/private/block_cipher.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief           Initialize the context.
+ *                  This must be the first API call before using the context.
+ *
+ * \param ctx       The context to initialize.
+ */
+static inline void mbedtls_block_cipher_init(mbedtls_block_cipher_context_t *ctx)
+{
+    memset(ctx, 0, sizeof(*ctx));
+}
+
+/**
+ * \brief           Set the block cipher to use with this context.
+ *                  This must be called after mbedtls_block_cipher_init().
+ *
+ * \param ctx       The context to set up.
+ * \param cipher_id The identifier of the cipher to use.
+ *                  This must be either AES, ARIA or Camellia.
+ *                  Warning: this is a ::mbedtls_cipher_id_t,
+ *                  not a ::mbedtls_block_cipher_id_t!
+ *
+ * \retval          \c 0 on success.
+ * \retval          #MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA if \p cipher_id was
+ *                  invalid.
+ */
+int mbedtls_block_cipher_setup(mbedtls_block_cipher_context_t *ctx,
+                               mbedtls_cipher_id_t cipher_id);
+
+/**
+ * \brief           Set the key into the context.
+ *
+ * \param ctx       The context to configure.
+ * \param key       The buffer holding the key material.
+ * \param key_bitlen    The size of the key in bits.
+ *
+ * \retval          \c 0 on success.
+ * \retval          #MBEDTLS_ERR_CIPHER_INVALID_CONTEXT if the context was not
+ *                  properly set up before calling this function.
+ * \retval          One of #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH,
+ *                  #MBEDTLS_ERR_ARIA_BAD_INPUT_DATA,
+ *                  #MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA if \p key_bitlen is
+ *                  invalid.
+ */
+int mbedtls_block_cipher_setkey(mbedtls_block_cipher_context_t *ctx,
+                                const unsigned char *key,
+                                unsigned key_bitlen);
+
+/**
+ * \brief           Encrypt one block (16 bytes) with the configured key.
+ *
+ * \param ctx       The context holding the key.
+ * \param input     The buffer holding the input block. Must be 16 bytes.
+ * \param output    The buffer to which the output block will be written.
+ *                  Must be writable and 16 bytes long.
+ *                  This must either not overlap with \p input, or be equal.
+ *
+ * \retval          \c 0 on success.
+ * \retval          #MBEDTLS_ERR_CIPHER_INVALID_CONTEXT if the context was not
+ *                  properly set up before calling this function.
+ * \retval          Another negative value if encryption failed.
+ */
+int mbedtls_block_cipher_encrypt(mbedtls_block_cipher_context_t *ctx,
+                                 const unsigned char input[16],
+                                 unsigned char output[16]);
+/**
+ * \brief           Clear the context.
+ *
+ * \param ctx       The context to clear.
+ */
+void mbedtls_block_cipher_free(mbedtls_block_cipher_context_t *ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TF_PSA_CRYPTO_BLOCK_CIPHER_INTERNAL_H */

--- a/legacy_sub/src/ecp.c
+++ b/legacy_sub/src/ecp.c
@@ -281,7 +281,9 @@ int mbedtls_ecp_check_budget(const mbedtls_ecp_group *grp,
 
 #endif /* MBEDTLS_ECP_RESTARTABLE */
 
-#if defined(MBEDTLS_ECP_C)
+#if defined(MBEDTLS_ECP_C) && \
+    (defined(MBEDTLS_ECP_SHORT_WEIERSTRASS_ENABLED) || \
+     defined(MBEDTLS_ECP_MONTGOMERY_ENABLED))
 static void mpi_init_many(mbedtls_mpi *arr, size_t size)
 {
     while (size--) {
@@ -295,7 +297,7 @@ static void mpi_free_many(mbedtls_mpi *arr, size_t size)
         mbedtls_mpi_free(arr++);
     }
 }
-#endif /* MBEDTLS_ECP_C */
+#endif
 
 /*
  * List of supported curves:
@@ -708,6 +710,7 @@ int mbedtls_ecp_point_write_binary(const mbedtls_ecp_group *grp,
     }
 #endif
 
+    (void)&&cleanup;
 cleanup:
     return ret;
 }
@@ -787,6 +790,7 @@ int mbedtls_ecp_point_read_binary(const mbedtls_ecp_group *grp,
     }
 #endif
 
+    (void)&&cleanup;
 cleanup:
     return ret;
 }

--- a/legacy_sub/src/md5.c
+++ b/legacy_sub/src/md5.c
@@ -1,0 +1,419 @@
+/*
+ *  RFC 1321 compliant MD5 implementation
+ *
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+/*
+ *  The MD5 algorithm was designed by Ron Rivest in 1991.
+ *
+ *  http://www.ietf.org/rfc/rfc1321.txt
+ */
+
+#include "tf_psa_crypto_common.h"
+
+#if defined(MBEDTLS_MD5_C)
+
+#include "mbedtls/private/md5.h"
+#include "mbedtls/platform_util.h"
+#include "mbedtls/private/error_common.h"
+
+#include <string.h>
+
+#include "mbedtls/platform.h"
+
+void mbedtls_md5_init(mbedtls_md5_context *ctx)
+{
+    memset(ctx, 0, sizeof(mbedtls_md5_context));
+}
+
+void mbedtls_md5_free(mbedtls_md5_context *ctx)
+{
+    if (ctx == NULL) {
+        return;
+    }
+
+    mbedtls_platform_zeroize(ctx, sizeof(mbedtls_md5_context));
+}
+
+void mbedtls_md5_clone(mbedtls_md5_context *dst,
+                       const mbedtls_md5_context *src)
+{
+    *dst = *src;
+}
+
+/*
+ * MD5 context setup
+ */
+int mbedtls_md5_starts(mbedtls_md5_context *ctx)
+{
+    ctx->total[0] = 0;
+    ctx->total[1] = 0;
+
+    ctx->state[0] = 0x67452301;
+    ctx->state[1] = 0xEFCDAB89;
+    ctx->state[2] = 0x98BADCFE;
+    ctx->state[3] = 0x10325476;
+
+    return 0;
+}
+
+static int mbedtls_internal_md5_process(mbedtls_md5_context *ctx,
+                                        const unsigned char data[64])
+{
+    struct {
+        uint32_t X[16], A, B, C, D;
+    } local;
+
+    local.X[0] = MBEDTLS_GET_UINT32_LE(data,  0);
+    local.X[1] = MBEDTLS_GET_UINT32_LE(data,  4);
+    local.X[2] = MBEDTLS_GET_UINT32_LE(data,  8);
+    local.X[3] = MBEDTLS_GET_UINT32_LE(data, 12);
+    local.X[4] = MBEDTLS_GET_UINT32_LE(data, 16);
+    local.X[5] = MBEDTLS_GET_UINT32_LE(data, 20);
+    local.X[6] = MBEDTLS_GET_UINT32_LE(data, 24);
+    local.X[7] = MBEDTLS_GET_UINT32_LE(data, 28);
+    local.X[8] = MBEDTLS_GET_UINT32_LE(data, 32);
+    local.X[9] = MBEDTLS_GET_UINT32_LE(data, 36);
+    local.X[10] = MBEDTLS_GET_UINT32_LE(data, 40);
+    local.X[11] = MBEDTLS_GET_UINT32_LE(data, 44);
+    local.X[12] = MBEDTLS_GET_UINT32_LE(data, 48);
+    local.X[13] = MBEDTLS_GET_UINT32_LE(data, 52);
+    local.X[14] = MBEDTLS_GET_UINT32_LE(data, 56);
+    local.X[15] = MBEDTLS_GET_UINT32_LE(data, 60);
+
+#define S(x, n)                                                          \
+    (((x) << (n)) | (((x) & 0xFFFFFFFF) >> (32 - (n))))
+
+#define P(a, b, c, d, k, s, t)                                                \
+    do                                                                  \
+    {                                                                   \
+        (a) += F((b), (c), (d)) + local.X[(k)] + (t);                     \
+        (a) = S((a), (s)) + (b);                                         \
+    } while (0)
+
+    local.A = ctx->state[0];
+    local.B = ctx->state[1];
+    local.C = ctx->state[2];
+    local.D = ctx->state[3];
+
+#define F(x, y, z) ((z) ^ ((x) & ((y) ^ (z))))
+
+    P(local.A, local.B, local.C, local.D,  0,  7, 0xD76AA478);
+    P(local.D, local.A, local.B, local.C,  1, 12, 0xE8C7B756);
+    P(local.C, local.D, local.A, local.B,  2, 17, 0x242070DB);
+    P(local.B, local.C, local.D, local.A,  3, 22, 0xC1BDCEEE);
+    P(local.A, local.B, local.C, local.D,  4,  7, 0xF57C0FAF);
+    P(local.D, local.A, local.B, local.C,  5, 12, 0x4787C62A);
+    P(local.C, local.D, local.A, local.B,  6, 17, 0xA8304613);
+    P(local.B, local.C, local.D, local.A,  7, 22, 0xFD469501);
+    P(local.A, local.B, local.C, local.D,  8,  7, 0x698098D8);
+    P(local.D, local.A, local.B, local.C,  9, 12, 0x8B44F7AF);
+    P(local.C, local.D, local.A, local.B, 10, 17, 0xFFFF5BB1);
+    P(local.B, local.C, local.D, local.A, 11, 22, 0x895CD7BE);
+    P(local.A, local.B, local.C, local.D, 12,  7, 0x6B901122);
+    P(local.D, local.A, local.B, local.C, 13, 12, 0xFD987193);
+    P(local.C, local.D, local.A, local.B, 14, 17, 0xA679438E);
+    P(local.B, local.C, local.D, local.A, 15, 22, 0x49B40821);
+
+#undef F
+
+#define F(x, y, z) ((y) ^ ((z) & ((x) ^ (y))))
+
+    P(local.A, local.B, local.C, local.D,  1,  5, 0xF61E2562);
+    P(local.D, local.A, local.B, local.C,  6,  9, 0xC040B340);
+    P(local.C, local.D, local.A, local.B, 11, 14, 0x265E5A51);
+    P(local.B, local.C, local.D, local.A,  0, 20, 0xE9B6C7AA);
+    P(local.A, local.B, local.C, local.D,  5,  5, 0xD62F105D);
+    P(local.D, local.A, local.B, local.C, 10,  9, 0x02441453);
+    P(local.C, local.D, local.A, local.B, 15, 14, 0xD8A1E681);
+    P(local.B, local.C, local.D, local.A,  4, 20, 0xE7D3FBC8);
+    P(local.A, local.B, local.C, local.D,  9,  5, 0x21E1CDE6);
+    P(local.D, local.A, local.B, local.C, 14,  9, 0xC33707D6);
+    P(local.C, local.D, local.A, local.B,  3, 14, 0xF4D50D87);
+    P(local.B, local.C, local.D, local.A,  8, 20, 0x455A14ED);
+    P(local.A, local.B, local.C, local.D, 13,  5, 0xA9E3E905);
+    P(local.D, local.A, local.B, local.C,  2,  9, 0xFCEFA3F8);
+    P(local.C, local.D, local.A, local.B,  7, 14, 0x676F02D9);
+    P(local.B, local.C, local.D, local.A, 12, 20, 0x8D2A4C8A);
+
+#undef F
+
+#define F(x, y, z) ((x) ^ (y) ^ (z))
+
+    P(local.A, local.B, local.C, local.D,  5,  4, 0xFFFA3942);
+    P(local.D, local.A, local.B, local.C,  8, 11, 0x8771F681);
+    P(local.C, local.D, local.A, local.B, 11, 16, 0x6D9D6122);
+    P(local.B, local.C, local.D, local.A, 14, 23, 0xFDE5380C);
+    P(local.A, local.B, local.C, local.D,  1,  4, 0xA4BEEA44);
+    P(local.D, local.A, local.B, local.C,  4, 11, 0x4BDECFA9);
+    P(local.C, local.D, local.A, local.B,  7, 16, 0xF6BB4B60);
+    P(local.B, local.C, local.D, local.A, 10, 23, 0xBEBFBC70);
+    P(local.A, local.B, local.C, local.D, 13,  4, 0x289B7EC6);
+    P(local.D, local.A, local.B, local.C,  0, 11, 0xEAA127FA);
+    P(local.C, local.D, local.A, local.B,  3, 16, 0xD4EF3085);
+    P(local.B, local.C, local.D, local.A,  6, 23, 0x04881D05);
+    P(local.A, local.B, local.C, local.D,  9,  4, 0xD9D4D039);
+    P(local.D, local.A, local.B, local.C, 12, 11, 0xE6DB99E5);
+    P(local.C, local.D, local.A, local.B, 15, 16, 0x1FA27CF8);
+    P(local.B, local.C, local.D, local.A,  2, 23, 0xC4AC5665);
+
+#undef F
+
+#define F(x, y, z) ((y) ^ ((x) | ~(z)))
+
+    P(local.A, local.B, local.C, local.D,  0,  6, 0xF4292244);
+    P(local.D, local.A, local.B, local.C,  7, 10, 0x432AFF97);
+    P(local.C, local.D, local.A, local.B, 14, 15, 0xAB9423A7);
+    P(local.B, local.C, local.D, local.A,  5, 21, 0xFC93A039);
+    P(local.A, local.B, local.C, local.D, 12,  6, 0x655B59C3);
+    P(local.D, local.A, local.B, local.C,  3, 10, 0x8F0CCC92);
+    P(local.C, local.D, local.A, local.B, 10, 15, 0xFFEFF47D);
+    P(local.B, local.C, local.D, local.A,  1, 21, 0x85845DD1);
+    P(local.A, local.B, local.C, local.D,  8,  6, 0x6FA87E4F);
+    P(local.D, local.A, local.B, local.C, 15, 10, 0xFE2CE6E0);
+    P(local.C, local.D, local.A, local.B,  6, 15, 0xA3014314);
+    P(local.B, local.C, local.D, local.A, 13, 21, 0x4E0811A1);
+    P(local.A, local.B, local.C, local.D,  4,  6, 0xF7537E82);
+    P(local.D, local.A, local.B, local.C, 11, 10, 0xBD3AF235);
+    P(local.C, local.D, local.A, local.B,  2, 15, 0x2AD7D2BB);
+    P(local.B, local.C, local.D, local.A,  9, 21, 0xEB86D391);
+
+#undef F
+
+    ctx->state[0] += local.A;
+    ctx->state[1] += local.B;
+    ctx->state[2] += local.C;
+    ctx->state[3] += local.D;
+
+    /* Zeroise variables to clear sensitive data from memory. */
+    mbedtls_platform_zeroize(&local, sizeof(local));
+
+    return 0;
+}
+
+/*
+ * MD5 process buffer
+ */
+int mbedtls_md5_update(mbedtls_md5_context *ctx,
+                       const unsigned char *input,
+                       size_t ilen)
+{
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+    size_t fill;
+    uint32_t left;
+
+    if (ilen == 0) {
+        return 0;
+    }
+
+    left = ctx->total[0] & 0x3F;
+    fill = 64 - left;
+
+    ctx->total[0] += (uint32_t) ilen;
+    ctx->total[0] &= 0xFFFFFFFF;
+
+    if (ctx->total[0] < (uint32_t) ilen) {
+        ctx->total[1]++;
+    }
+
+    if (left && ilen >= fill) {
+        memcpy((void *) (ctx->buffer + left), input, fill);
+        if ((ret = mbedtls_internal_md5_process(ctx, ctx->buffer)) != 0) {
+            return ret;
+        }
+
+        input += fill;
+        ilen  -= fill;
+        left = 0;
+    }
+
+    while (ilen >= 64) {
+        if ((ret = mbedtls_internal_md5_process(ctx, input)) != 0) {
+            return ret;
+        }
+
+        input += 64;
+        ilen  -= 64;
+    }
+
+    if (ilen > 0) {
+        memcpy((void *) (ctx->buffer + left), input, ilen);
+    }
+
+    return 0;
+}
+
+/*
+ * MD5 final digest
+ */
+int mbedtls_md5_finish(mbedtls_md5_context *ctx,
+                       unsigned char output[16])
+{
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+    uint32_t used;
+    uint32_t high, low;
+
+    /*
+     * Add padding: 0x80 then 0x00 until 8 bytes remain for the length
+     */
+    used = ctx->total[0] & 0x3F;
+
+    ctx->buffer[used++] = 0x80;
+
+    if (used <= 56) {
+        /* Enough room for padding + length in current block */
+        memset(ctx->buffer + used, 0, 56 - used);
+    } else {
+        /* We'll need an extra block */
+        memset(ctx->buffer + used, 0, 64 - used);
+
+        if ((ret = mbedtls_internal_md5_process(ctx, ctx->buffer)) != 0) {
+            goto exit;
+        }
+
+        memset(ctx->buffer, 0, 56);
+    }
+
+    /*
+     * Add message length
+     */
+    high = (ctx->total[0] >> 29)
+           | (ctx->total[1] <<  3);
+    low  = (ctx->total[0] <<  3);
+
+    MBEDTLS_PUT_UINT32_LE(low,  ctx->buffer, 56);
+    MBEDTLS_PUT_UINT32_LE(high, ctx->buffer, 60);
+
+    if ((ret = mbedtls_internal_md5_process(ctx, ctx->buffer)) != 0) {
+        goto exit;
+    }
+
+    /*
+     * Output final state
+     */
+    MBEDTLS_PUT_UINT32_LE(ctx->state[0], output,  0);
+    MBEDTLS_PUT_UINT32_LE(ctx->state[1], output,  4);
+    MBEDTLS_PUT_UINT32_LE(ctx->state[2], output,  8);
+    MBEDTLS_PUT_UINT32_LE(ctx->state[3], output, 12);
+
+    ret = 0;
+
+exit:
+    mbedtls_md5_free(ctx);
+    return ret;
+}
+
+/*
+ * output = MD5( input buffer )
+ */
+int mbedtls_md5(const unsigned char *input,
+                size_t ilen,
+                unsigned char output[16])
+{
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+    mbedtls_md5_context ctx;
+
+    mbedtls_md5_init(&ctx);
+
+    if ((ret = mbedtls_md5_starts(&ctx)) != 0) {
+        goto exit;
+    }
+
+    if ((ret = mbedtls_md5_update(&ctx, input, ilen)) != 0) {
+        goto exit;
+    }
+
+    if ((ret = mbedtls_md5_finish(&ctx, output)) != 0) {
+        goto exit;
+    }
+
+exit:
+    mbedtls_md5_free(&ctx);
+
+    return ret;
+}
+
+#if defined(MBEDTLS_SELF_TEST)
+/*
+ * RFC 1321 test vectors
+ */
+static const unsigned char md5_test_buf[7][81] =
+{
+    { "" },
+    { "a" },
+    { "abc" },
+    { "message digest" },
+    { "abcdefghijklmnopqrstuvwxyz" },
+    { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
+    { "12345678901234567890123456789012345678901234567890123456789012345678901234567890" }
+};
+
+static const size_t md5_test_buflen[7] =
+{
+    0, 1, 3, 14, 26, 62, 80
+};
+
+static const unsigned char md5_test_sum[7][16] =
+{
+    { 0xD4, 0x1D, 0x8C, 0xD9, 0x8F, 0x00, 0xB2, 0x04,
+      0xE9, 0x80, 0x09, 0x98, 0xEC, 0xF8, 0x42, 0x7E },
+    { 0x0C, 0xC1, 0x75, 0xB9, 0xC0, 0xF1, 0xB6, 0xA8,
+      0x31, 0xC3, 0x99, 0xE2, 0x69, 0x77, 0x26, 0x61 },
+    { 0x90, 0x01, 0x50, 0x98, 0x3C, 0xD2, 0x4F, 0xB0,
+      0xD6, 0x96, 0x3F, 0x7D, 0x28, 0xE1, 0x7F, 0x72 },
+    { 0xF9, 0x6B, 0x69, 0x7D, 0x7C, 0xB7, 0x93, 0x8D,
+      0x52, 0x5A, 0x2F, 0x31, 0xAA, 0xF1, 0x61, 0xD0 },
+    { 0xC3, 0xFC, 0xD3, 0xD7, 0x61, 0x92, 0xE4, 0x00,
+      0x7D, 0xFB, 0x49, 0x6C, 0xCA, 0x67, 0xE1, 0x3B },
+    { 0xD1, 0x74, 0xAB, 0x98, 0xD2, 0x77, 0xD9, 0xF5,
+      0xA5, 0x61, 0x1C, 0x2C, 0x9F, 0x41, 0x9D, 0x9F },
+    { 0x57, 0xED, 0xF4, 0xA2, 0x2B, 0xE3, 0xC9, 0x55,
+      0xAC, 0x49, 0xDA, 0x2E, 0x21, 0x07, 0xB6, 0x7A }
+};
+
+/*
+ * Checkup routine
+ */
+int mbedtls_md5_self_test(int verbose)
+{
+    int i, ret = 0;
+    unsigned char md5sum[16];
+
+    for (i = 0; i < 7; i++) {
+        if (verbose != 0) {
+            mbedtls_printf("  MD5 test #%d: ", i + 1);
+        }
+
+        ret = mbedtls_md5(md5_test_buf[i], md5_test_buflen[i], md5sum);
+        if (ret != 0) {
+            goto fail;
+        }
+
+        if (memcmp(md5sum, md5_test_sum[i], 16) != 0) {
+            ret = 1;
+            goto fail;
+        }
+
+        if (verbose != 0) {
+            mbedtls_printf("passed\n");
+        }
+    }
+
+    if (verbose != 0) {
+        mbedtls_printf("\n");
+    }
+
+    return 0;
+
+fail:
+    if (verbose != 0) {
+        mbedtls_printf("failed\n");
+    }
+
+    return ret;
+}
+
+#endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_MD5_C */

--- a/oberon/drivers/oberon_check_unsupported.h
+++ b/oberon/drivers/oberon_check_unsupported.h
@@ -9,739 +9,737 @@
 #ifndef OBERON_CHECK_UNSUPPORTED_H
 #define OBERON_CHECK_UNSUPPORTED_H
 
-#include "psa/crypto_driver_config.h"
-
 /* Currently Unsupported Algorithms */
 
-#if defined(PSA_WANT_ALG_SHA_512_224) && !defined(PSA_ACCEL_SHA_512_224)
-    #error "No software implementation for SHA-512-224"
+#if defined(CONFIG_PSA_WANT_ALG_SHA_512_224) && !defined(CONFIG_PSA_ACCEL_SHA_512_224)
+    #error "No crypto implementation for SHA-512-224"
 #endif
-#if defined(PSA_WANT_ALG_SHA_512_256) && !defined(PSA_ACCEL_SHA_512_256)
-    #error "No software implementation for SHA-512-256"
+#if defined(CONFIG_PSA_WANT_ALG_SHA_512_256) && !defined(CONFIG_PSA_ACCEL_SHA_512_256)
+    #error "No crypto implementation for SHA-512-256"
 #endif
-#if defined(PSA_WANT_ALG_MD2) && !defined(PSA_ACCEL_MD2)
-    #error "No software implementation for MD2"
+#if defined(CONFIG_PSA_WANT_ALG_MD2) && !defined(CONFIG_PSA_ACCEL_MD2)
+    #error "No crypto implementation for MD2"
 #endif
-#if defined(PSA_WANT_ALG_MD4) && !defined(PSA_ACCEL_MD4)
-    #error "No software implementation for MD4"
+#if defined(CONFIG_PSA_WANT_ALG_MD4) && !defined(CONFIG_PSA_ACCEL_MD4)
+    #error "No crypto implementation for MD4"
 #endif
-#if defined(PSA_WANT_ALG_MD5) && !defined(PSA_ACCEL_MD5)
-    #error "No software implementation for MD5"
+#if defined(CONFIG_PSA_WANT_ALG_MD5) && !defined(CONFIG_PSA_ACCEL_MD5)
+    #error "No crypto implementation for MD5"
 #endif
-#if defined(PSA_WANT_ALG_RIPEMD160) && !defined(PSA_ACCEL_RIPEMD160)
-    #error "No software implementation for RIPEMD160"
+#if defined(CONFIG_PSA_WANT_ALG_RIPEMD160) && !defined(CONFIG_PSA_ACCEL_RIPEMD160)
+    #error "No crypto implementation for RIPEMD160"
 #endif
-#if defined(PSA_WANT_ALG_AES_MMO_ZIGBEE) && !defined(PSA_ACCEL_AES_MMO_ZIGBEE)
-    #error "No software implementation for AES_MMO_ZIGBEE"
+#if defined(CONFIG_PSA_WANT_ALG_AES_MMO_ZIGBEE) && !defined(CONFIG_PSA_ACCEL_AES_MMO_ZIGBEE)
+    #error "No crypto implementation for AES_MMO_ZIGBEE"
 #endif
-#if defined(PSA_WANT_ALG_SM3) && !defined(PSA_ACCEL_SM3)
-    #error "No software implementation for SM3"
+#if defined(CONFIG_PSA_WANT_ALG_SM3) && !defined(CONFIG_PSA_ACCEL_SM3)
+    #error "No crypto implementation for SM3"
 #endif
-#if defined(PSA_WANT_ALG_EDDSA_CTX) && !defined(PSA_ACCEL_EDDSA_CTX)
-    #error "No software implementation for EDDSA_CTX"
+#if defined(CONFIG_PSA_WANT_ALG_EDDSA_CTX) && !defined(CONFIG_PSA_ACCEL_EDDSA_CTX)
+    #error "No crypto implementation for EDDSA_CTX"
 #endif
-#if defined(PSA_WANT_ALG_ECIES_SEC1) && !defined(PSA_ACCEL_ECIES_SEC1)
-    #error "No software implementation for ECIES_SEC1"
-#endif
-
-#if (defined(PSA_WANT_ALG_SLH_DSA) || \
-     defined(PSA_WANT_ALG_DETERMINISTIC_SLH_DSA) || \
-     defined(PSA_WANT_ALG_HASH_SLH_DSA) || \
-     defined(PSA_WANT_ALG_DETERMINISTIC_HASH_SLH_DSA)) && !defined(PSA_ACCEL_SLH_DSA)
-    #error "No software implementation for SLH-DSA"
+#if defined(CONFIG_PSA_WANT_ALG_ECIES_SEC1) && !defined(CONFIG_PSA_ACCEL_ECIES_SEC1)
+    #error "No crypto implementation for ECIES_SEC1"
 #endif
 
-#if defined(PSA_WANT_KEY_TYPE_AES) && defined(PSA_WANT_ALG_CFB)
-    #if defined(PSA_WANT_AES_KEY_SIZE_128) && !defined(PSA_ACCEL_CFB_AES_128)
-        #error "No software implementation for 128 bit AES-CFB"
-    #endif
-    #if defined(PSA_WANT_AES_KEY_SIZE_192) && !defined(PSA_ACCEL_CFB_AES_192)
-        #error "No software implementation for 192 bit AES-CFB"
-    #endif
-    #if defined(PSA_WANT_AES_KEY_SIZE_256) && !defined(PSA_ACCEL_CFB_AES_256)
-        #error "No software implementation for 256 bit AES-CFB"
-    #endif
-#endif
-#if defined(PSA_WANT_KEY_TYPE_AES) && defined(PSA_WANT_ALG_OFB)
-    #if defined(PSA_WANT_AES_KEY_SIZE_128) && !defined(PSA_ACCEL_OFB_AES_128)
-        #error "No software implementation for 128 bit AES-OFB"
-    #endif
-    #if defined(PSA_WANT_AES_KEY_SIZE_192) && !defined(PSA_ACCEL_OFB_AES_192)
-        #error "No software implementation for 192 bit AES-OFB"
-    #endif
-    #if defined(PSA_WANT_AES_KEY_SIZE_256) && !defined(PSA_ACCEL_OFB_AES_256)
-        #error "No software implementation for 256 bit AES-OFB"
-    #endif
-#endif
-#if defined(PSA_WANT_KEY_TYPE_AES) && defined(PSA_WANT_ALG_XTS)
-    #if defined(PSA_WANT_AES_KEY_SIZE_128) && !defined(PSA_ACCEL_XTS_AES_128)
-        #error "No software implementation for 128 bit AES-XTS"
-    #endif
-    #if defined(PSA_WANT_AES_KEY_SIZE_192) && !defined(PSA_ACCEL_XTS_AES_192)
-        #error "No software implementation for 192 bit AES-XTS"
-    #endif
-    #if defined(PSA_WANT_AES_KEY_SIZE_256) && !defined(PSA_ACCEL_XTS_AES_256)
-        #error "No software implementation for 256 bit AES-XTS"
-    #endif
-#endif
-#if defined(PSA_WANT_KEY_TYPE_AES) && defined(PSA_WANT_ALG_CBC_MAC)
-    #if defined(PSA_WANT_AES_KEY_SIZE_128) && !defined(PSA_ACCEL_CBC_MAC_AES_128)
-        #error "No software implementation for 128 bit AES-CBC-MAC"
-    #endif
-    #if defined(PSA_WANT_AES_KEY_SIZE_192) && !defined(PSA_ACCEL_CBC_MAC_AES_192)
-        #error "No software implementation for 192 bit AES-CBC-MAC"
-    #endif
-    #if defined(PSA_WANT_AES_KEY_SIZE_256) && !defined(PSA_ACCEL_CBC_MAC_AES_256)
-        #error "No software implementation for 256 bit AES-CBC-MAC"
-    #endif
+#if (defined(CONFIG_PSA_WANT_ALG_SLH_DSA) || \
+     defined(CONFIG_PSA_WANT_ALG_DETERMINISTIC_SLH_DSA) || \
+     defined(CONFIG_PSA_WANT_ALG_HASH_SLH_DSA) || \
+     defined(CONFIG_PSA_WANT_ALG_DETERMINISTIC_HASH_SLH_DSA)) && !defined(CONFIG_PSA_ACCEL_SLH_DSA)
+    #error "No crypto implementation for SLH-DSA"
 #endif
 
-#if defined(PSA_WANT_ALG_FFDH)
-    #if defined(PSA_WANT_DH_KEY_SIZE_2048) && !defined(PSA_ACCEL_FFDH_2048)
-        #error "No software implementation for 2048 bit FFDH"
+#if defined(CONFIG_PSA_WANT_KEY_TYPE_AES) && defined(CONFIG_PSA_WANT_ALG_CFB)
+    #if defined(CONFIG_PSA_WANT_AES_KEY_SIZE_128) && !defined(CONFIG_PSA_ACCEL_CFB_AES_128)
+        #error "No crypto implementation for 128 bit AES-CFB"
     #endif
-    #if defined(PSA_WANT_DH_KEY_SIZE_3072) && !defined(PSA_ACCEL_FFDH_3072)
-        #error "No software implementation for 3072 bit FFDH"
+    #if defined(CONFIG_PSA_WANT_AES_KEY_SIZE_192) && !defined(CONFIG_PSA_ACCEL_CFB_AES_192)
+        #error "No crypto implementation for 192 bit AES-CFB"
     #endif
-    #if defined(PSA_WANT_DH_KEY_SIZE_4096) && !defined(PSA_ACCEL_FFDH_4096)
-        #error "No software implementation for 4096 bit FFDH"
+    #if defined(CONFIG_PSA_WANT_AES_KEY_SIZE_256) && !defined(CONFIG_PSA_ACCEL_CFB_AES_256)
+        #error "No crypto implementation for 256 bit AES-CFB"
     #endif
-    #if defined(PSA_WANT_DH_KEY_SIZE_6144) && !defined(PSA_ACCEL_FFDH_6144)
-        #error "No software implementation for 6144 bit FFDH"
+#endif
+#if defined(CONFIG_PSA_WANT_KEY_TYPE_AES) && defined(CONFIG_PSA_WANT_ALG_OFB)
+    #if defined(CONFIG_PSA_WANT_AES_KEY_SIZE_128) && !defined(CONFIG_PSA_ACCEL_OFB_AES_128)
+        #error "No crypto implementation for 128 bit AES-OFB"
     #endif
-    #if defined(PSA_WANT_DH_KEY_SIZE_8192) && !defined(PSA_ACCEL_FFDH_8192)
-        #error "No software implementation for 8192 bit FFDH"
+    #if defined(CONFIG_PSA_WANT_AES_KEY_SIZE_192) && !defined(CONFIG_PSA_ACCEL_OFB_AES_192)
+        #error "No crypto implementation for 192 bit AES-OFB"
+    #endif
+    #if defined(CONFIG_PSA_WANT_AES_KEY_SIZE_256) && !defined(CONFIG_PSA_ACCEL_OFB_AES_256)
+        #error "No crypto implementation for 256 bit AES-OFB"
+    #endif
+#endif
+#if defined(CONFIG_PSA_WANT_KEY_TYPE_AES) && defined(CONFIG_PSA_WANT_ALG_XTS)
+    #if defined(CONFIG_PSA_WANT_AES_KEY_SIZE_128) && !defined(CONFIG_PSA_ACCEL_XTS_AES_128)
+        #error "No crypto implementation for 128 bit AES-XTS"
+    #endif
+    #if defined(CONFIG_PSA_WANT_AES_KEY_SIZE_192) && !defined(CONFIG_PSA_ACCEL_XTS_AES_192)
+        #error "No crypto implementation for 192 bit AES-XTS"
+    #endif
+    #if defined(CONFIG_PSA_WANT_AES_KEY_SIZE_256) && !defined(CONFIG_PSA_ACCEL_XTS_AES_256)
+        #error "No crypto implementation for 256 bit AES-XTS"
+    #endif
+#endif
+#if defined(CONFIG_PSA_WANT_KEY_TYPE_AES) && defined(CONFIG_PSA_WANT_ALG_CBC_MAC)
+    #if defined(CONFIG_PSA_WANT_AES_KEY_SIZE_128) && !defined(CONFIG_PSA_ACCEL_CBC_MAC_AES_128)
+        #error "No crypto implementation for 128 bit AES-CBC-MAC"
+    #endif
+    #if defined(CONFIG_PSA_WANT_AES_KEY_SIZE_192) && !defined(CONFIG_PSA_ACCEL_CBC_MAC_AES_192)
+        #error "No crypto implementation for 192 bit AES-CBC-MAC"
+    #endif
+    #if defined(CONFIG_PSA_WANT_AES_KEY_SIZE_256) && !defined(CONFIG_PSA_ACCEL_CBC_MAC_AES_256)
+        #error "No crypto implementation for 256 bit AES-CBC-MAC"
     #endif
 #endif
 
-#if defined(PSA_WANT_ECC_SECP_K1_192)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECP_K1_192)
-        #error "No software implementation for secp-k1-192 public key"
+#if defined(CONFIG_PSA_WANT_ALG_FFDH)
+    #if defined(CONFIG_PSA_WANT_DH_KEY_SIZE_2048) && !defined(CONFIG_PSA_ACCEL_FFDH_2048)
+        #error "No crypto implementation for 2048 bit FFDH"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECP_K1_192)
-        #error "No software implementation for secp-k1-192 key pair import"
+    #if defined(CONFIG_PSA_WANT_DH_KEY_SIZE_3072) && !defined(CONFIG_PSA_ACCEL_FFDH_3072)
+        #error "No crypto implementation for 3072 bit FFDH"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECP_K1_192)
-        #error "No software implementation for secp-k1-192 key pair export"
+    #if defined(CONFIG_PSA_WANT_DH_KEY_SIZE_4096) && !defined(CONFIG_PSA_ACCEL_FFDH_4096)
+        #error "No crypto implementation for 4096 bit FFDH"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECP_K1_192)
-        #error "No software implementation for secp-k1-192 key pair generate"
+    #if defined(CONFIG_PSA_WANT_DH_KEY_SIZE_6144) && !defined(CONFIG_PSA_ACCEL_FFDH_6144)
+        #error "No crypto implementation for 6144 bit FFDH"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECP_K1_192)
-        #error "No software implementation for secp-k1-192 key pair derive"
-    #endif
-#endif
-
-#if defined(PSA_WANT_ECC_SECP_K1_224)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECP_K1_224)
-        #error "No software implementation for secp-k1-224 public key"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECP_K1_224)
-        #error "No software implementation for secp-k1-224 key pair import"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECP_K1_224)
-        #error "No software implementation for secp-k1-224 key pair export"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECP_K1_224)
-        #error "No software implementation for secp-k1-224 key pair generate"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECP_K1_224)
-        #error "No software implementation for secp-k1-224 key pair derive"
+    #if defined(CONFIG_PSA_WANT_DH_KEY_SIZE_8192) && !defined(CONFIG_PSA_ACCEL_FFDH_8192)
+        #error "No crypto implementation for 8192 bit FFDH"
     #endif
 #endif
 
-#if defined(PSA_WANT_ECC_SECP_R1_192)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECP_R1_192)
-        #error "No software implementation for secp-r1-192 public key"
+#if defined(CONFIG_PSA_WANT_ECC_SECP_K1_192)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECP_K1_192)
+        #error "No crypto implementation for secp-k1-192 public key"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECP_R1_192)
-        #error "No software implementation for secp-r1-192 key pair import"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECP_K1_192)
+        #error "No crypto implementation for secp-k1-192 key pair import"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECP_R1_192)
-        #error "No software implementation for secp-r1-192 key pair export"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECP_K1_192)
+        #error "No crypto implementation for secp-k1-192 key pair export"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECP_R1_192)
-        #error "No software implementation for secp-r1-192 key pair generate"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECP_K1_192)
+        #error "No crypto implementation for secp-k1-192 key pair generate"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECP_R1_192)
-        #error "No software implementation for secp-r1-192 key pair derive"
-    #endif
-#endif
-
-#if defined(PSA_WANT_ECC_SECP_R2_160)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECP_R2_160)
-        #error "No software implementation for secp-r2-160 public key"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECP_R2_160)
-        #error "No software implementation for secp-r2-160 key pair import"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECP_R2_160)
-        #error "No software implementation for secp-r2-160 key pair export"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECP_R2_160)
-        #error "No software implementation for secp-r2-160 key pair generate"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECP_R2_160)
-        #error "No software implementation for secp-r2-160 key pair derive"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECP_K1_192)
+        #error "No crypto implementation for secp-k1-192 key pair derive"
     #endif
 #endif
 
-#if defined(PSA_WANT_ECC_SECT_K1_163)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_K1_163)
-        #error "No software implementation for sect-k1-163 public key"
+#if defined(CONFIG_PSA_WANT_ECC_SECP_K1_224)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECP_K1_224)
+        #error "No crypto implementation for secp-k1-224 public key"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_K1_163)
-        #error "No software implementation for sect-k1-163 key pair import"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECP_K1_224)
+        #error "No crypto implementation for secp-k1-224 key pair import"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_K1_163)
-        #error "No software implementation for sect-k1-163 key pair export"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECP_K1_224)
+        #error "No crypto implementation for secp-k1-224 key pair export"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_K1_163)
-        #error "No software implementation for sect-k1-163 key pair generate"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECP_K1_224)
+        #error "No crypto implementation for secp-k1-224 key pair generate"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_K1_163)
-        #error "No software implementation for sect-k1-163 key pair derive"
-    #endif
-#endif
-
-#if defined(PSA_WANT_ECC_SECT_K1_233)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_K1_233)
-        #error "No software implementation for sect-k1-233 public key"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_K1_233)
-        #error "No software implementation for sect-k1-233 key pair import"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_K1_233)
-        #error "No software implementation for sect-k1-233 key pair export"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_K1_233)
-        #error "No software implementation for sect-k1-233 key pair generate"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_K1_233)
-        #error "No software implementation for sect-k1-233 key pair derive"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECP_K1_224)
+        #error "No crypto implementation for secp-k1-224 key pair derive"
     #endif
 #endif
 
-#if defined(PSA_WANT_ECC_SECT_K1_239)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_K1_239)
-        #error "No software implementation for sect-k1-239 public key"
+#if defined(CONFIG_PSA_WANT_ECC_SECP_R1_192)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECP_R1_192)
+        #error "No crypto implementation for secp-r1-192 public key"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_K1_239)
-        #error "No software implementation for sect-k1-239 key pair import"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECP_R1_192)
+        #error "No crypto implementation for secp-r1-192 key pair import"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_K1_239)
-        #error "No software implementation for sect-k1-239 key pair export"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECP_R1_192)
+        #error "No crypto implementation for secp-r1-192 key pair export"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_K1_239)
-        #error "No software implementation for sect-k1-239 key pair generate"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECP_R1_192)
+        #error "No crypto implementation for secp-r1-192 key pair generate"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_K1_239)
-        #error "No software implementation for sect-k1-239 key pair derive"
-    #endif
-#endif
-
-#if defined(PSA_WANT_ECC_SECT_K1_283)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_K1_283)
-        #error "No software implementation for sect-k1-283 public key"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_K1_283)
-        #error "No software implementation for sect-k1-283 key pair import"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_K1_283)
-        #error "No software implementation for sect-k1-283 key pair export"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_K1_283)
-        #error "No software implementation for sect-k1-283 key pair generate"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_K1_283)
-        #error "No software implementation for sect-k1-283 key pair derive"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECP_R1_192)
+        #error "No crypto implementation for secp-r1-192 key pair derive"
     #endif
 #endif
 
-#if defined(PSA_WANT_ECC_SECT_K1_409)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_K1_409)
-        #error "No software implementation for sect-k1-409 public key"
+#if defined(CONFIG_PSA_WANT_ECC_SECP_R2_160)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECP_R2_160)
+        #error "No crypto implementation for secp-r2-160 public key"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_K1_409)
-        #error "No software implementation for sect-k1-409 key pair import"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECP_R2_160)
+        #error "No crypto implementation for secp-r2-160 key pair import"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_K1_409)
-        #error "No software implementation for sect-k1-409 key pair export"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECP_R2_160)
+        #error "No crypto implementation for secp-r2-160 key pair export"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_K1_409)
-        #error "No software implementation for sect-k1-409 key pair generate"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECP_R2_160)
+        #error "No crypto implementation for secp-r2-160 key pair generate"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_K1_409)
-        #error "No software implementation for sect-k1-409 key pair derive"
-    #endif
-#endif
-
-#if defined(PSA_WANT_ECC_SECT_K1_571)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_K1_571)
-        #error "No software implementation for sect-k1-571 public key"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_K1_571)
-        #error "No software implementation for sect-k1-571 key pair import"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_K1_571)
-        #error "No software implementation for sect-k1-571 key pair export"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_K1_571)
-        #error "No software implementation for sect-k1-571 key pair generate"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_K1_571)
-        #error "No software implementation for sect-k1-571 key pair derive"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECP_R2_160)
+        #error "No crypto implementation for secp-r2-160 key pair derive"
     #endif
 #endif
 
-#if defined(PSA_WANT_ECC_SECT_R1_163)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_R1_163)
-        #error "No software implementation for sect-r1-163 public key"
+#if defined(CONFIG_PSA_WANT_ECC_SECT_K1_163)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_K1_163)
+        #error "No crypto implementation for sect-k1-163 public key"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_R1_163)
-        #error "No software implementation for sect-r1-163 key pair import"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_K1_163)
+        #error "No crypto implementation for sect-k1-163 key pair import"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_R1_163)
-        #error "No software implementation for sect-r1-163 key pair export"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_K1_163)
+        #error "No crypto implementation for sect-k1-163 key pair export"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_R1_163)
-        #error "No software implementation for sect-r1-163 key pair generate"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_K1_163)
+        #error "No crypto implementation for sect-k1-163 key pair generate"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_R1_163)
-        #error "No software implementation for sect-r1-163 key pair derive"
-    #endif
-#endif
-
-#if defined(PSA_WANT_ECC_SECT_R1_233)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_R1_233)
-        #error "No software implementation for sect-r1-233 public key"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_R1_233)
-        #error "No software implementation for sect-r1-233 key pair import"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_R1_233)
-        #error "No software implementation for sect-r1-233 key pair export"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_R1_233)
-        #error "No software implementation for sect-r1-233 key pair generate"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_R1_233)
-        #error "No software implementation for sect-r1-233 key pair derive"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_K1_163)
+        #error "No crypto implementation for sect-k1-163 key pair derive"
     #endif
 #endif
 
-#if defined(PSA_WANT_ECC_SECT_R1_283)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_R1_283)
-        #error "No software implementation for sect-r1-283 public key"
+#if defined(CONFIG_PSA_WANT_ECC_SECT_K1_233)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_K1_233)
+        #error "No crypto implementation for sect-k1-233 public key"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_R1_283)
-        #error "No software implementation for sect-r1-283 key pair import"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_K1_233)
+        #error "No crypto implementation for sect-k1-233 key pair import"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_R1_283)
-        #error "No software implementation for sect-r1-283 key pair export"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_K1_233)
+        #error "No crypto implementation for sect-k1-233 key pair export"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_R1_283)
-        #error "No software implementation for sect-r1-283 key pair generate"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_K1_233)
+        #error "No crypto implementation for sect-k1-233 key pair generate"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_R1_283)
-        #error "No software implementation for sect-r1-283 key pair derive"
-    #endif
-#endif
-
-#if defined(PSA_WANT_ECC_SECT_R1_409)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_R1_409)
-        #error "No software implementation for sect-r1-409 public key"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_R1_409)
-        #error "No software implementation for sect-r1-409 key pair import"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_R1_409)
-        #error "No software implementation for sect-r1-409 key pair export"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_R1_409)
-        #error "No software implementation for sect-r1-409 key pair generate"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_R1_409)
-        #error "No software implementation for sect-r1-409 key pair derive"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_K1_233)
+        #error "No crypto implementation for sect-k1-233 key pair derive"
     #endif
 #endif
 
-#if defined(PSA_WANT_ECC_SECT_R1_571)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_R1_571)
-        #error "No software implementation for sect-r1-571 public key"
+#if defined(CONFIG_PSA_WANT_ECC_SECT_K1_239)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_K1_239)
+        #error "No crypto implementation for sect-k1-239 public key"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_R1_571)
-        #error "No software implementation for sect-r1-571 key pair import"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_K1_239)
+        #error "No crypto implementation for sect-k1-239 key pair import"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_R1_571)
-        #error "No software implementation for sect-r1-571 key pair export"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_K1_239)
+        #error "No crypto implementation for sect-k1-239 key pair export"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_R1_571)
-        #error "No software implementation for sect-r1-571 key pair generate"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_K1_239)
+        #error "No crypto implementation for sect-k1-239 key pair generate"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_R1_571)
-        #error "No software implementation for sect-r1-571 key pair derive"
-    #endif
-#endif
-
-#if defined(PSA_WANT_ECC_SECT_R2_163)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_R2_163)
-        #error "No software implementation for sect-r2-163 public key"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_R2_163)
-        #error "No software implementation for sect-r2-163 key pair import"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_R2_163)
-        #error "No software implementation for sect-r2-163 key pair export"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_R2_163)
-        #error "No software implementation for sect-r2-163 key pair generate"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_R2_163)
-        #error "No software implementation for sect-r2-163 key pair derive"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_K1_239)
+        #error "No crypto implementation for sect-k1-239 key pair derive"
     #endif
 #endif
 
-#if defined(PSA_WANT_ECC_BRAINPOOL_P_R1_160)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_BRAINPOOL_P_R1_160)
-        #error "No software implementation for brainpoolP160r1 public key"
+#if defined(CONFIG_PSA_WANT_ECC_SECT_K1_283)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_K1_283)
+        #error "No crypto implementation for sect-k1-283 public key"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_BRAINPOOL_P_R1_160)
-        #error "No software implementation for brainpoolP160r1 key pair import"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_K1_283)
+        #error "No crypto implementation for sect-k1-283 key pair import"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_BRAINPOOL_P_R1_160)
-        #error "No software implementation for brainpoolP160r1 key pair export"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_K1_283)
+        #error "No crypto implementation for sect-k1-283 key pair export"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_BRAINPOOL_P_R1_160)
-        #error "No software implementation for brainpoolP160r1 key pair generate"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_K1_283)
+        #error "No crypto implementation for sect-k1-283 key pair generate"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_BRAINPOOL_P_R1_160)
-        #error "No software implementation for brainpoolP160r1 key pair derive"
-    #endif
-#endif
-
-#if defined(PSA_WANT_ECC_BRAINPOOL_P_R1_192)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_BRAINPOOL_P_R1_192)
-        #error "No software implementation for brainpoolP192r1 public key"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_BRAINPOOL_P_R1_192)
-        #error "No software implementation for brainpoolP192r1 key pair import"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_BRAINPOOL_P_R1_192)
-        #error "No software implementation for brainpoolP192r1 key pair export"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_BRAINPOOL_P_R1_192)
-        #error "No software implementation for brainpoolP192r1 key pair generate"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_BRAINPOOL_P_R1_192)
-        #error "No software implementation for brainpoolP192r1 key pair derive"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_K1_283)
+        #error "No crypto implementation for sect-k1-283 key pair derive"
     #endif
 #endif
 
-#if defined(PSA_WANT_ECC_BRAINPOOL_P_R1_224)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_BRAINPOOL_P_R1_224)
-        #error "No software implementation for brainpoolP224r1 public key"
+#if defined(CONFIG_PSA_WANT_ECC_SECT_K1_409)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_K1_409)
+        #error "No crypto implementation for sect-k1-409 public key"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_BRAINPOOL_P_R1_224)
-        #error "No software implementation for brainpoolP224r1 key pair import"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_K1_409)
+        #error "No crypto implementation for sect-k1-409 key pair import"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_BRAINPOOL_P_R1_224)
-        #error "No software implementation for brainpoolP224r1 key pair export"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_K1_409)
+        #error "No crypto implementation for sect-k1-409 key pair export"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_BRAINPOOL_P_R1_224)
-        #error "No software implementation for brainpoolP224r1 key pair generate"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_K1_409)
+        #error "No crypto implementation for sect-k1-409 key pair generate"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_BRAINPOOL_P_R1_224)
-        #error "No software implementation for brainpoolP224r1 key pair derive"
-    #endif
-#endif
-
-#if defined(PSA_WANT_ECC_BRAINPOOL_P_R1_256)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_BRAINPOOL_P_R1_256)
-        #error "No software implementation for brainpoolP256r1 public key"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_BRAINPOOL_P_R1_256)
-        #error "No software implementation for brainpoolP256r1 key pair import"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_BRAINPOOL_P_R1_256)
-        #error "No software implementation for brainpoolP256r1 key pair export"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_BRAINPOOL_P_R1_256)
-        #error "No software implementation for brainpoolP256r1 key pair generate"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_BRAINPOOL_P_R1_256)
-        #error "No software implementation for brainpoolP256r1 key pair derive"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_K1_409)
+        #error "No crypto implementation for sect-k1-409 key pair derive"
     #endif
 #endif
 
-#if defined(PSA_WANT_ECC_BRAINPOOL_P_R1_320)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_BRAINPOOL_P_R1_320)
-        #error "No software implementation for brainpoolP320r1 public key"
+#if defined(CONFIG_PSA_WANT_ECC_SECT_K1_571)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_K1_571)
+        #error "No crypto implementation for sect-k1-571 public key"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_BRAINPOOL_P_R1_320)
-        #error "No software implementation for brainpoolP320r1 key pair import"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_K1_571)
+        #error "No crypto implementation for sect-k1-571 key pair import"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_BRAINPOOL_P_R1_320)
-        #error "No software implementation for brainpoolP320r1 key pair export"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_K1_571)
+        #error "No crypto implementation for sect-k1-571 key pair export"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_BRAINPOOL_P_R1_320)
-        #error "No software implementation for brainpoolP320r1 key pair generate"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_K1_571)
+        #error "No crypto implementation for sect-k1-571 key pair generate"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_BRAINPOOL_P_R1_320)
-        #error "No software implementation for brainpoolP320r1 key pair derive"
-    #endif
-#endif
-
-#if defined(PSA_WANT_ECC_BRAINPOOL_P_R1_384)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_BRAINPOOL_P_R1_384)
-        #error "No software implementation for brainpoolP384r1 public key"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_BRAINPOOL_P_R1_384)
-        #error "No software implementation for brainpoolP384r1 key pair import"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_BRAINPOOL_P_R1_384)
-        #error "No software implementation for brainpoolP384r1 key pair export"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_BRAINPOOL_P_R1_384)
-        #error "No software implementation for brainpoolP384r1 key pair generate"
-    #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_BRAINPOOL_P_R1_384)
-        #error "No software implementation for brainpoolP384r1 key pair derive"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_K1_571)
+        #error "No crypto implementation for sect-k1-571 key pair derive"
     #endif
 #endif
 
-#if defined(PSA_WANT_ECC_BRAINPOOL_P_R1_512)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_BRAINPOOL_P_R1_512)
-        #error "No software implementation for brainpoolP512r1 public key"
+#if defined(CONFIG_PSA_WANT_ECC_SECT_R1_163)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_R1_163)
+        #error "No crypto implementation for sect-r1-163 public key"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_BRAINPOOL_P_R1_512)
-        #error "No software implementation for brainpoolP512r1 key pair import"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_R1_163)
+        #error "No crypto implementation for sect-r1-163 key pair import"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_BRAINPOOL_P_R1_512)
-        #error "No software implementation for brainpoolP512r1 key pair export"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_R1_163)
+        #error "No crypto implementation for sect-r1-163 key pair export"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_BRAINPOOL_P_R1_512)
-        #error "No software implementation for brainpoolP512r1 key pair generate"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_R1_163)
+        #error "No crypto implementation for sect-r1-163 key pair generate"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && \
-        !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_BRAINPOOL_P_R1_512)
-        #error "No software implementation for brainpoolP512r1 key pair derive"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_R1_163)
+        #error "No crypto implementation for sect-r1-163 key pair derive"
     #endif
 #endif
 
-#if defined(PSA_WANT_ECC_FRP)
-    #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_FRP_256)
-        #error "No software implementation for FRP256v1 public key"
+#if defined(CONFIG_PSA_WANT_ECC_SECT_R1_233)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_R1_233)
+        #error "No crypto implementation for sect-r1-233 public key"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_FRP_256)
-        #error "No software implementation for FRP256v1 key pair import"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_R1_233)
+        #error "No crypto implementation for sect-r1-233 key pair import"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_FRP_256)
-        #error "No software implementation for FRP256v1 key pair export"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_R1_233)
+        #error "No crypto implementation for sect-r1-233 key pair export"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_FRP_256)
-        #error "No software implementation for FRP256v1 key pair generate"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_R1_233)
+        #error "No crypto implementation for sect-r1-233 key pair generate"
     #endif
-    #if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_FRP_256)
-        #error "No software implementation for FRP256v1 key pair derive"
-    #endif
-#endif
-
-#if defined(PSA_WANT_KEY_TYPE_ARIA)
-    #if defined(PSA_WANT_ALG_CCM) && !defined(PSA_ACCEL_CCM_ARIA)
-        #error "No software implementation for ARIA-CCM"
-    #endif
-    #if defined(PSA_WANT_ALG_GCM) && !defined(PSA_ACCEL_GCM_ARIA)
-        #error "No software implementation for ARIA-GCM"
-    #endif
-    #if defined(PSA_WANT_ALG_CTR) && !defined(PSA_ACCEL_CTR_ARIA)
-        #error "No software implementation for ARIA-CTR"
-    #endif
-    #if defined(PSA_WANT_ALG_CBC_PKCS7) && !defined(PSA_ACCEL_CBC_PKCS7_ARIA)
-        #error "No software implementation for ARIA-CBC-PKCS7"
-    #endif
-    #if defined(PSA_WANT_ALG_CBC_NO_PADDING) && !defined(PSA_ACCEL_CBC_NO_PADDING_ARIA)
-        #error "No software implementation for ARIA-CBC-no-padding"
-    #endif
-    #if defined(PSA_WANT_ALG_ECB_NO_PADDING) && !defined(PSA_ACCEL_ECB_NO_PADDING_ARIA)
-        #error "No software implementation for ARIA-ECB-no-padding"
-    #endif
-    #if defined(PSA_WANT_ALG_CFB) && !defined(PSA_ACCEL_CFB_ARIA)
-        #error "No software implementation for ARIA-CFB"
-    #endif
-    #if defined(PSA_WANT_ALG_OFB) && !defined(PSA_ACCEL_OFB_ARIA)
-        #error "No software implementation for ARIA-OFB"
-    #endif
-    #if defined(PSA_WANT_ALG_XTS) && !defined(PSA_ACCEL_XTS_ARIA)
-        #error "No software implementation for ARIA-XTS"
-    #endif
-    #if defined(PSA_WANT_ALG_CBC_MAC) && !defined(PSA_ACCEL_CBC_MAC_ARIA)
-        #error "No software implementation for ARIA-CBC-MAC"
-    #endif
-    #if defined(PSA_WANT_ALG_CMAC) && !defined(PSA_ACCEL_CMAC_ARIA)
-        #error "No software implementation for ARIA-CMAC"
-    #endif
-    #if defined(PSA_WANT_ALG_KW) && !defined(PSA_ACCEL_KW_ARIA)
-        #error "No software implementation for ARIA-KW"
-    #endif
-    #if defined(PSA_WANT_ALG_KWP) && !defined(PSA_ACCEL_KWP_ARIA)
-        #error "No software implementation for ARIA-KWP"
-    #endif
-    #if defined(PSA_WANT_ALG_SP800_108_COUNTER_CMAC) && !defined(PSA_ACCEL_SP800_108_COUNTER_CMAC_ARIA)
-        #error "No software implementation for ARIA-SP800-108-counter-CMAC"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_R1_233)
+        #error "No crypto implementation for sect-r1-233 key pair derive"
     #endif
 #endif
 
-#if defined(PSA_WANT_KEY_TYPE_CAMELLIA)
-    #if defined(PSA_WANT_ALG_CCM) && !defined(PSA_ACCEL_CCM_CAMELLIA)
-        #error "No software implementation for CAMELLIA-CCM"
+#if defined(CONFIG_PSA_WANT_ECC_SECT_R1_283)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_R1_283)
+        #error "No crypto implementation for sect-r1-283 public key"
     #endif
-    #if defined(PSA_WANT_ALG_GCM) && !defined(PSA_ACCEL_GCM_CAMELLIA)
-        #error "No software implementation for CAMELLIA-GCM"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_R1_283)
+        #error "No crypto implementation for sect-r1-283 key pair import"
     #endif
-    #if defined(PSA_WANT_ALG_CTR) && !defined(PSA_ACCEL_CTR_CAMELLIA)
-        #error "No software implementation for CAMELLIA-CTR"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_R1_283)
+        #error "No crypto implementation for sect-r1-283 key pair export"
     #endif
-    #if defined(PSA_WANT_ALG_CBC_PKCS7) && !defined(PSA_ACCEL_CBC_PKCS7_CAMELLIA)
-        #error "No software implementation for CAMELLIA-CBC-PKCS7"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_R1_283)
+        #error "No crypto implementation for sect-r1-283 key pair generate"
     #endif
-    #if defined(PSA_WANT_ALG_CBC_NO_PADDING) && !defined(PSA_ACCEL_CBC_NO_PADDING_CAMELLIA)
-        #error "No software implementation for CAMELLIA-CBC-no-padding"
-    #endif
-    #if defined(PSA_WANT_ALG_ECB_NO_PADDING) && !defined(PSA_ACCEL_ECB_NO_PADDING_CAMELLIA)
-        #error "No software implementation for CAMELLIA-ECB-no-padding"
-    #endif
-    #if defined(PSA_WANT_ALG_CFB) && !defined(PSA_ACCEL_CFB_CAMELLIA)
-        #error "No software implementation for CAMELLIA-CFB"
-    #endif
-    #if defined(PSA_WANT_ALG_OFB) && !defined(PSA_ACCEL_OFB_CAMELLIA)
-        #error "No software implementation for CAMELLIA-OFB"
-    #endif
-    #if defined(PSA_WANT_ALG_XTS) && !defined(PSA_ACCEL_XTS_CAMELLIA)
-        #error "No software implementation for CAMELLIA-XTS"
-    #endif
-    #if defined(PSA_WANT_ALG_CBC_MAC) && !defined(PSA_ACCEL_CBC_MAC_CAMELLIA)
-        #error "No software implementation for CAMELLIA-CBC-MAC"
-    #endif
-    #if defined(PSA_WANT_ALG_CMAC) && !defined(PSA_ACCEL_CMAC_CAMELLIA)
-        #error "No software implementation for CAMELLIA-CMAC"
-    #endif
-    #if defined(PSA_WANT_ALG_KW) && !defined(PSA_ACCEL_KW_CAMELLIA)
-        #error "No software implementation for CAMELLIA-KW"
-    #endif
-    #if defined(PSA_WANT_ALG_KWP) && !defined(PSA_ACCEL_KWP_CAMELLIA)
-        #error "No software implementation for CAMELLIA-KWP"
-    #endif
-    #if defined(PSA_WANT_ALG_SP800_108_COUNTER_CMAC) && !defined(PSA_ACCEL_SP800_108_COUNTER_CMAC_CAMELLIA)
-        #error "No software implementation for CAMELLIA-SP800-108-counter-CMAC"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_R1_283)
+        #error "No crypto implementation for sect-r1-283 key pair derive"
     #endif
 #endif
 
-#if defined(PSA_WANT_KEY_TYPE_DES)
-    #if defined(PSA_WANT_ALG_CTR) && !defined(PSA_ACCEL_CTR_DES)
-        #error "No software implementation for DES-CTR"
+#if defined(CONFIG_PSA_WANT_ECC_SECT_R1_409)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_R1_409)
+        #error "No crypto implementation for sect-r1-409 public key"
     #endif
-    #if defined(PSA_WANT_ALG_CBC_PKCS7) && !defined(PSA_ACCEL_CBC_PKCS7_DES)
-        #error "No software implementation for DES-CBC-PKCS7"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_R1_409)
+        #error "No crypto implementation for sect-r1-409 key pair import"
     #endif
-    #if defined(PSA_WANT_ALG_CBC_NO_PADDING) && !defined(PSA_ACCEL_CBC_NO_PADDING_DES)
-        #error "No software implementation for DES-CBC-no-padding"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_R1_409)
+        #error "No crypto implementation for sect-r1-409 key pair export"
     #endif
-    #if defined(PSA_WANT_ALG_ECB_NO_PADDING) && !defined(PSA_ACCEL_ECB_NO_PADDING_DES)
-        #error "No software implementation for DES-ECB-no-padding"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_R1_409)
+        #error "No crypto implementation for sect-r1-409 key pair generate"
     #endif
-    #if defined(PSA_WANT_ALG_CFB) && !defined(PSA_ACCEL_CFB_DES)
-        #error "No software implementation for DES-CFB"
-    #endif
-    #if defined(PSA_WANT_ALG_OFB) && !defined(PSA_ACCEL_OFB_DES)
-        #error "No software implementation for DES-OFB"
-    #endif
-    #if defined(PSA_WANT_ALG_XTS) && !defined(PSA_ACCEL_XTS_DES)
-        #error "No software implementation for DES-XTS"
-    #endif
-    #if defined(PSA_WANT_ALG_CBC_MAC) && !defined(PSA_ACCEL_CBC_MAC_DES)
-        #error "No software implementation for DES-CBC-MAC"
-    #endif
-    #if defined(PSA_WANT_ALG_CMAC) && !defined(PSA_ACCEL_CMAC_DES)
-        #error "No software implementation for DES-CMAC"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_R1_409)
+        #error "No crypto implementation for sect-r1-409 key pair derive"
     #endif
 #endif
 
-#if defined(PSA_WANT_KEY_TYPE_SM4)
-    #if defined(PSA_WANT_ALG_CCM) && !defined(PSA_ACCEL_CCM_SM4)
-        #error "No software implementation for SM4-CCM"
+#if defined(CONFIG_PSA_WANT_ECC_SECT_R1_571)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_R1_571)
+        #error "No crypto implementation for sect-r1-571 public key"
     #endif
-    #if defined(PSA_WANT_ALG_GCM) && !defined(PSA_ACCEL_GCM_SM4)
-        #error "No software implementation for SM4-GCM"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_R1_571)
+        #error "No crypto implementation for sect-r1-571 key pair import"
     #endif
-    #if defined(PSA_WANT_ALG_CTR) && !defined(PSA_ACCEL_CTR_SM4)
-        #error "No software implementation for SM4-CTR"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_R1_571)
+        #error "No crypto implementation for sect-r1-571 key pair export"
     #endif
-    #if defined(PSA_WANT_ALG_CBC_PKCS7) && !defined(PSA_ACCEL_CBC_PKCS7_SM4)
-        #error "No software implementation for SM4-CBC-PKCS7"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_R1_571)
+        #error "No crypto implementation for sect-r1-571 key pair generate"
     #endif
-    #if defined(PSA_WANT_ALG_CBC_NO_PADDING) && !defined(PSA_ACCEL_CBC_NO_PADDING_SM4)
-        #error "No software implementation for SM4-CBC-no-padding"
-    #endif
-    #if defined(PSA_WANT_ALG_ECB_NO_PADDING) && !defined(PSA_ACCEL_ECB_NO_PADDING_SM4)
-        #error "No software implementation for SM4-ECB-no-padding"
-    #endif
-    #if defined(PSA_WANT_ALG_CFB) && !defined(PSA_ACCEL_CFB_SM4)
-        #error "No software implementation for SM4-CFB"
-    #endif
-    #if defined(PSA_WANT_ALG_OFB) && !defined(PSA_ACCEL_OFB_SM4)
-        #error "No software implementation for SM4-OFB"
-    #endif
-    #if defined(PSA_WANT_ALG_XTS) && !defined(PSA_ACCEL_XTS_SM4)
-        #error "No software implementation for SM4-XTS"
-    #endif
-    #if defined(PSA_WANT_ALG_CBC_MAC) && !defined(PSA_ACCEL_CBC_MAC_SM4)
-        #error "No software implementation for SM4-CBC-MAC"
-    #endif
-    #if defined(PSA_WANT_ALG_CMAC) && !defined(PSA_ACCEL_CMAC_SM4)
-        #error "No software implementation for SM4-CMAC"
-    #endif
-    #if defined(PSA_WANT_ALG_KW) && !defined(PSA_ACCEL_KW_SM4)
-        #error "No software implementation for SM4-KW"
-    #endif
-    #if defined(PSA_WANT_ALG_KWP) && !defined(PSA_ACCEL_KWP_SM4)
-        #error "No software implementation for SM4-KWP"
-    #endif
-    #if defined(PSA_WANT_ALG_SP800_108_COUNTER_CMAC) && !defined(PSA_ACCEL_SP800_108_COUNTER_CMAC_SM4)
-        #error "No software implementation for SM4-SP800-108-counter-CMAC"
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_R1_571)
+        #error "No crypto implementation for sect-r1-571 key pair derive"
     #endif
 #endif
 
-#if defined(PSA_WANT_KEY_TYPE_ARC4)
-    #if defined(PSA_WANT_ALG_STREAM_CIPHER) && !defined(PSA_ACCEL_STREAM_CIPHER_ARC4)
-        #error "No software implementation for ARC4"
+#if defined(CONFIG_PSA_WANT_ECC_SECT_R2_163)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_SECT_R2_163)
+        #error "No crypto implementation for sect-r2-163 public key"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_SECT_R2_163)
+        #error "No crypto implementation for sect-r2-163 key pair import"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_SECT_R2_163)
+        #error "No crypto implementation for sect-r2-163 key pair export"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECT_R2_163)
+        #error "No crypto implementation for sect-r2-163 key pair generate"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_SECT_R2_163)
+        #error "No crypto implementation for sect-r2-163 key pair derive"
+    #endif
+#endif
+
+#if defined(CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_160)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_BRAINPOOL_P_R1_160)
+        #error "No crypto implementation for brainpoolP160r1 public key"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_BRAINPOOL_P_R1_160)
+        #error "No crypto implementation for brainpoolP160r1 key pair import"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_BRAINPOOL_P_R1_160)
+        #error "No crypto implementation for brainpoolP160r1 key pair export"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_BRAINPOOL_P_R1_160)
+        #error "No crypto implementation for brainpoolP160r1 key pair generate"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_BRAINPOOL_P_R1_160)
+        #error "No crypto implementation for brainpoolP160r1 key pair derive"
+    #endif
+#endif
+
+#if defined(CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_192)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_BRAINPOOL_P_R1_192)
+        #error "No crypto implementation for brainpoolP192r1 public key"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_BRAINPOOL_P_R1_192)
+        #error "No crypto implementation for brainpoolP192r1 key pair import"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_BRAINPOOL_P_R1_192)
+        #error "No crypto implementation for brainpoolP192r1 key pair export"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_BRAINPOOL_P_R1_192)
+        #error "No crypto implementation for brainpoolP192r1 key pair generate"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_BRAINPOOL_P_R1_192)
+        #error "No crypto implementation for brainpoolP192r1 key pair derive"
+    #endif
+#endif
+
+#if defined(CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_224)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_BRAINPOOL_P_R1_224)
+        #error "No crypto implementation for brainpoolP224r1 public key"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_BRAINPOOL_P_R1_224)
+        #error "No crypto implementation for brainpoolP224r1 key pair import"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_BRAINPOOL_P_R1_224)
+        #error "No crypto implementation for brainpoolP224r1 key pair export"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_BRAINPOOL_P_R1_224)
+        #error "No crypto implementation for brainpoolP224r1 key pair generate"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_BRAINPOOL_P_R1_224)
+        #error "No crypto implementation for brainpoolP224r1 key pair derive"
+    #endif
+#endif
+
+#if defined(CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_256)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_BRAINPOOL_P_R1_256)
+        #error "No crypto implementation for brainpoolP256r1 public key"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_BRAINPOOL_P_R1_256)
+        #error "No crypto implementation for brainpoolP256r1 key pair import"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_BRAINPOOL_P_R1_256)
+        #error "No crypto implementation for brainpoolP256r1 key pair export"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_BRAINPOOL_P_R1_256)
+        #error "No crypto implementation for brainpoolP256r1 key pair generate"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_BRAINPOOL_P_R1_256)
+        #error "No crypto implementation for brainpoolP256r1 key pair derive"
+    #endif
+#endif
+
+#if defined(CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_320)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_BRAINPOOL_P_R1_320)
+        #error "No crypto implementation for brainpoolP320r1 public key"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_BRAINPOOL_P_R1_320)
+        #error "No crypto implementation for brainpoolP320r1 key pair import"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_BRAINPOOL_P_R1_320)
+        #error "No crypto implementation for brainpoolP320r1 key pair export"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_BRAINPOOL_P_R1_320)
+        #error "No crypto implementation for brainpoolP320r1 key pair generate"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_BRAINPOOL_P_R1_320)
+        #error "No crypto implementation for brainpoolP320r1 key pair derive"
+    #endif
+#endif
+
+#if defined(CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_384)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_BRAINPOOL_P_R1_384)
+        #error "No crypto implementation for brainpoolP384r1 public key"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_BRAINPOOL_P_R1_384)
+        #error "No crypto implementation for brainpoolP384r1 key pair import"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_BRAINPOOL_P_R1_384)
+        #error "No crypto implementation for brainpoolP384r1 key pair export"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_BRAINPOOL_P_R1_384)
+        #error "No crypto implementation for brainpoolP384r1 key pair generate"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_BRAINPOOL_P_R1_384)
+        #error "No crypto implementation for brainpoolP384r1 key pair derive"
+    #endif
+#endif
+
+#if defined(CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_512)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_BRAINPOOL_P_R1_512)
+        #error "No crypto implementation for brainpoolP512r1 public key"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_BRAINPOOL_P_R1_512)
+        #error "No crypto implementation for brainpoolP512r1 key pair import"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_BRAINPOOL_P_R1_512)
+        #error "No crypto implementation for brainpoolP512r1 key pair export"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_BRAINPOOL_P_R1_512)
+        #error "No crypto implementation for brainpoolP512r1 key pair generate"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && \
+        !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_BRAINPOOL_P_R1_512)
+        #error "No crypto implementation for brainpoolP512r1 key pair derive"
+    #endif
+#endif
+
+#if defined(CONFIG_PSA_WANT_ECC_FRP)
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_PUBLIC_KEY_FRP_256)
+        #error "No crypto implementation for FRP256v1 public key"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_IMPORT_FRP_256)
+        #error "No crypto implementation for FRP256v1 key pair import"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_EXPORT_FRP_256)
+        #error "No crypto implementation for FRP256v1 key pair export"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_GENERATE_FRP_256)
+        #error "No crypto implementation for FRP256v1 key pair generate"
+    #endif
+    #if defined(CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE) && !defined(CONFIG_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_DERIVE_FRP_256)
+        #error "No crypto implementation for FRP256v1 key pair derive"
+    #endif
+#endif
+
+#if defined(CONFIG_PSA_WANT_KEY_TYPE_ARIA)
+    #if defined(CONFIG_PSA_WANT_ALG_CCM) && !defined(CONFIG_PSA_ACCEL_CCM_ARIA)
+        #error "No crypto implementation for ARIA-CCM"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_GCM) && !defined(CONFIG_PSA_ACCEL_GCM_ARIA)
+        #error "No crypto implementation for ARIA-GCM"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_CTR) && !defined(CONFIG_PSA_ACCEL_CTR_ARIA)
+        #error "No crypto implementation for ARIA-CTR"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_CBC_PKCS7) && !defined(CONFIG_PSA_ACCEL_CBC_PKCS7_ARIA)
+        #error "No crypto implementation for ARIA-CBC-PKCS7"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_CBC_NO_PADDING) && !defined(CONFIG_PSA_ACCEL_CBC_NO_PADDING_ARIA)
+        #error "No crypto implementation for ARIA-CBC-no-padding"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_ECB_NO_PADDING) && !defined(CONFIG_PSA_ACCEL_ECB_NO_PADDING_ARIA)
+        #error "No crypto implementation for ARIA-ECB-no-padding"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_CFB) && !defined(CONFIG_PSA_ACCEL_CFB_ARIA)
+        #error "No crypto implementation for ARIA-CFB"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_OFB) && !defined(CONFIG_PSA_ACCEL_OFB_ARIA)
+        #error "No crypto implementation for ARIA-OFB"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_XTS) && !defined(CONFIG_PSA_ACCEL_XTS_ARIA)
+        #error "No crypto implementation for ARIA-XTS"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_CBC_MAC) && !defined(CONFIG_PSA_ACCEL_CBC_MAC_ARIA)
+        #error "No crypto implementation for ARIA-CBC-MAC"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_CMAC) && !defined(CONFIG_PSA_ACCEL_CMAC_ARIA)
+        #error "No crypto implementation for ARIA-CMAC"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_KW) && !defined(CONFIG_PSA_ACCEL_KW_ARIA)
+        #error "No crypto implementation for ARIA-KW"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_KWP) && !defined(CONFIG_PSA_ACCEL_KWP_ARIA)
+        #error "No crypto implementation for ARIA-KWP"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_CMAC) && !defined(CONFIG_PSA_ACCEL_SP800_108_COUNTER_CMAC_ARIA)
+        #error "No crypto implementation for ARIA-SP800-108-counter-CMAC"
+    #endif
+#endif
+
+#if defined(CONFIG_PSA_WANT_KEY_TYPE_CAMELLIA)
+    #if defined(CONFIG_PSA_WANT_ALG_CCM) && !defined(CONFIG_PSA_ACCEL_CCM_CAMELLIA)
+        #error "No crypto implementation for CAMELLIA-CCM"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_GCM) && !defined(CONFIG_PSA_ACCEL_GCM_CAMELLIA)
+        #error "No crypto implementation for CAMELLIA-GCM"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_CTR) && !defined(CONFIG_PSA_ACCEL_CTR_CAMELLIA)
+        #error "No crypto implementation for CAMELLIA-CTR"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_CBC_PKCS7) && !defined(CONFIG_PSA_ACCEL_CBC_PKCS7_CAMELLIA)
+        #error "No crypto implementation for CAMELLIA-CBC-PKCS7"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_CBC_NO_PADDING) && !defined(CONFIG_PSA_ACCEL_CBC_NO_PADDING_CAMELLIA)
+        #error "No crypto implementation for CAMELLIA-CBC-no-padding"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_ECB_NO_PADDING) && !defined(CONFIG_PSA_ACCEL_ECB_NO_PADDING_CAMELLIA)
+        #error "No crypto implementation for CAMELLIA-ECB-no-padding"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_CFB) && !defined(CONFIG_PSA_ACCEL_CFB_CAMELLIA)
+        #error "No crypto implementation for CAMELLIA-CFB"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_OFB) && !defined(CONFIG_PSA_ACCEL_OFB_CAMELLIA)
+        #error "No crypto implementation for CAMELLIA-OFB"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_XTS) && !defined(CONFIG_PSA_ACCEL_XTS_CAMELLIA)
+        #error "No crypto implementation for CAMELLIA-XTS"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_CBC_MAC) && !defined(CONFIG_PSA_ACCEL_CBC_MAC_CAMELLIA)
+        #error "No crypto implementation for CAMELLIA-CBC-MAC"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_CMAC) && !defined(CONFIG_PSA_ACCEL_CMAC_CAMELLIA)
+        #error "No crypto implementation for CAMELLIA-CMAC"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_KW) && !defined(CONFIG_PSA_ACCEL_KW_CAMELLIA)
+        #error "No crypto implementation for CAMELLIA-KW"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_KWP) && !defined(CONFIG_PSA_ACCEL_KWP_CAMELLIA)
+        #error "No crypto implementation for CAMELLIA-KWP"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_CMAC) && !defined(CONFIG_PSA_ACCEL_SP800_108_COUNTER_CMAC_CAMELLIA)
+        #error "No crypto implementation for CAMELLIA-SP800-108-counter-CMAC"
+    #endif
+#endif
+
+#if defined(CONFIG_PSA_WANT_KEY_TYPE_DES)
+    #if defined(CONFIG_PSA_WANT_ALG_CTR) && !defined(CONFIG_PSA_ACCEL_CTR_DES)
+        #error "No crypto implementation for DES-CTR"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_CBC_PKCS7) && !defined(CONFIG_PSA_ACCEL_CBC_PKCS7_DES)
+        #error "No crypto implementation for DES-CBC-PKCS7"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_CBC_NO_PADDING) && !defined(CONFIG_PSA_ACCEL_CBC_NO_PADDING_DES)
+        #error "No crypto implementation for DES-CBC-no-padding"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_ECB_NO_PADDING) && !defined(CONFIG_PSA_ACCEL_ECB_NO_PADDING_DES)
+        #error "No crypto implementation for DES-ECB-no-padding"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_CFB) && !defined(CONFIG_PSA_ACCEL_CFB_DES)
+        #error "No crypto implementation for DES-CFB"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_OFB) && !defined(CONFIG_PSA_ACCEL_OFB_DES)
+        #error "No crypto implementation for DES-OFB"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_XTS) && !defined(CONFIG_PSA_ACCEL_XTS_DES)
+        #error "No crypto implementation for DES-XTS"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_CBC_MAC) && !defined(CONFIG_PSA_ACCEL_CBC_MAC_DES)
+        #error "No crypto implementation for DES-CBC-MAC"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_CMAC) && !defined(CONFIG_PSA_ACCEL_CMAC_DES)
+        #error "No crypto implementation for DES-CMAC"
+    #endif
+#endif
+
+#if defined(CONFIG_PSA_WANT_KEY_TYPE_SM4)
+    #if defined(CONFIG_PSA_WANT_ALG_CCM) && !defined(CONFIG_PSA_ACCEL_CCM_SM4)
+        #error "No crypto implementation for SM4-CCM"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_GCM) && !defined(CONFIG_PSA_ACCEL_GCM_SM4)
+        #error "No crypto implementation for SM4-GCM"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_CTR) && !defined(CONFIG_PSA_ACCEL_CTR_SM4)
+        #error "No crypto implementation for SM4-CTR"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_CBC_PKCS7) && !defined(CONFIG_PSA_ACCEL_CBC_PKCS7_SM4)
+        #error "No crypto implementation for SM4-CBC-PKCS7"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_CBC_NO_PADDING) && !defined(CONFIG_PSA_ACCEL_CBC_NO_PADDING_SM4)
+        #error "No crypto implementation for SM4-CBC-no-padding"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_ECB_NO_PADDING) && !defined(CONFIG_PSA_ACCEL_ECB_NO_PADDING_SM4)
+        #error "No crypto implementation for SM4-ECB-no-padding"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_CFB) && !defined(CONFIG_PSA_ACCEL_CFB_SM4)
+        #error "No crypto implementation for SM4-CFB"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_OFB) && !defined(CONFIG_PSA_ACCEL_OFB_SM4)
+        #error "No crypto implementation for SM4-OFB"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_XTS) && !defined(CONFIG_PSA_ACCEL_XTS_SM4)
+        #error "No crypto implementation for SM4-XTS"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_CBC_MAC) && !defined(CONFIG_PSA_ACCEL_CBC_MAC_SM4)
+        #error "No crypto implementation for SM4-CBC-MAC"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_CMAC) && !defined(CONFIG_PSA_ACCEL_CMAC_SM4)
+        #error "No crypto implementation for SM4-CMAC"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_KW) && !defined(CONFIG_PSA_ACCEL_KW_SM4)
+        #error "No crypto implementation for SM4-KW"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_KWP) && !defined(CONFIG_PSA_ACCEL_KWP_SM4)
+        #error "No crypto implementation for SM4-KWP"
+    #endif
+    #if defined(CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_CMAC) && !defined(CONFIG_PSA_ACCEL_SP800_108_COUNTER_CMAC_SM4)
+        #error "No crypto implementation for SM4-SP800-108-counter-CMAC"
+    #endif
+#endif
+
+#if defined(CONFIG_PSA_WANT_KEY_TYPE_ARC4)
+    #if defined(CONFIG_PSA_WANT_ALG_STREAM_CIPHER) && !defined(CONFIG_PSA_ACCEL_STREAM_CIPHER_ARC4)
+        #error "No crypto implementation for ARC4"
     #endif
 #endif
 

--- a/oberon/drivers/oberon_ec_keys.c
+++ b/oberon/drivers/oberon_ec_keys.c
@@ -89,7 +89,7 @@ psa_status_t oberon_export_ec_public_key(
     _Static_assert(OCRYPTO_VERSION_NUMBER >= MIN_REQUIRED_OCRYPTO_VERSION, 
         "EC Keys Oberon driver: ocrypto version incompatible");
     int res = 1;
-    size_t bits = psa_get_key_bits(attributes);
+    __attribute__((unused)) size_t bits = psa_get_key_bits(attributes);
     psa_key_type_t type = psa_get_key_type(attributes);
 
     if (PSA_KEY_TYPE_IS_PUBLIC_KEY(type)) {

--- a/oberon/drivers/oberon_eddsa.c
+++ b/oberon/drivers/oberon_eddsa.c
@@ -124,6 +124,7 @@ psa_status_t oberon_eddsa_sign_message_with_context(
         switch (psa_get_key_bits(attributes)) {
 #ifdef PSA_NEED_OBERON_PURE_EDDSA_TWISTED_EDWARDS_255
         case 255:
+            if (alg == PSA_ALG_ED25519PH) return PSA_ERROR_NOT_SUPPORTED;
             if (key_length != ocrypto_ed25519_SECRET_KEY_BYTES) return PSA_ERROR_INVALID_ARGUMENT;
             if (signature_size < ocrypto_ed25519_BYTES) return PSA_ERROR_BUFFER_TOO_SMALL;
             *signature_length = ocrypto_ed25519_BYTES;
@@ -133,6 +134,7 @@ psa_status_t oberon_eddsa_sign_message_with_context(
 #endif
 #ifdef PSA_NEED_OBERON_PURE_EDDSA_TWISTED_EDWARDS_448
         case 448:
+            if (alg == PSA_ALG_ED448PH) return PSA_ERROR_NOT_SUPPORTED;
             if (key_length != ocrypto_ed448_SECRET_KEY_BYTES) return PSA_ERROR_INVALID_ARGUMENT;
             if (signature_size < ocrypto_ed448_BYTES) return PSA_ERROR_BUFFER_TOO_SMALL;
             *signature_length = ocrypto_ed448_BYTES;
@@ -255,6 +257,7 @@ psa_status_t oberon_eddsa_verify_message_with_context(
         switch (psa_get_key_bits(attributes)) {
 #ifdef PSA_NEED_OBERON_PURE_EDDSA_TWISTED_EDWARDS_255
         case 255:
+            if (alg == PSA_ALG_ED25519PH) return PSA_ERROR_NOT_SUPPORTED;
             if (key_length != ocrypto_ed25519_PUBLIC_KEY_BYTES) return PSA_ERROR_INVALID_ARGUMENT;
             if (signature_length != ocrypto_ed25519_BYTES) return PSA_ERROR_INVALID_SIGNATURE;
             if (type == PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_TWISTED_EDWARDS)) {
@@ -266,6 +269,7 @@ psa_status_t oberon_eddsa_verify_message_with_context(
 #endif /* PSA_NEED_OBERON_PURE_EDDSA_TWISTED_EDWARDS_255 */
 #ifdef PSA_NEED_OBERON_PURE_EDDSA_TWISTED_EDWARDS_448
         case 448:
+            if (alg == PSA_ALG_ED448PH) return PSA_ERROR_NOT_SUPPORTED;
             if (key_length != ocrypto_ed448_PUBLIC_KEY_BYTES) return PSA_ERROR_INVALID_ARGUMENT;
             if (signature_length != ocrypto_ed448_BYTES) return PSA_ERROR_INVALID_SIGNATURE;
             if (type == PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_TWISTED_EDWARDS)) {

--- a/platform/memory_buffer_alloc.c
+++ b/platform/memory_buffer_alloc.c
@@ -1,0 +1,751 @@
+/*
+ *  Buffer-based memory allocator
+ *
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+
+#include "tf_psa_crypto_common.h"
+
+#if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
+#include "mbedtls/memory_buffer_alloc.h"
+
+/* No need for the header guard as MBEDTLS_MEMORY_BUFFER_ALLOC_C
+   is dependent upon MBEDTLS_PLATFORM_C */
+#include "mbedtls/platform.h"
+#include "mbedtls/platform_util.h"
+
+#include <string.h>
+
+#if defined(MBEDTLS_MEMORY_BACKTRACE)
+#include <execinfo.h>
+#endif
+
+#if defined(MBEDTLS_THREADING_C)
+#include "mbedtls/threading.h"
+#endif
+
+#define MAGIC1       0xFF00AA55
+#define MAGIC2       0xEE119966
+#define MAX_BT 20
+
+typedef struct _memory_header memory_header;
+struct _memory_header {
+    size_t          magic1;
+    size_t          size;
+    size_t          alloc;
+    memory_header   *prev;
+    memory_header   *next;
+    memory_header   *prev_free;
+    memory_header   *next_free;
+#if defined(MBEDTLS_MEMORY_BACKTRACE)
+    char            **trace;
+    size_t          trace_count;
+#endif
+    size_t          magic2;
+};
+
+typedef struct {
+    unsigned char   *buf;
+    size_t          len;
+    memory_header   *first;
+    memory_header   *first_free;
+    int             verify;
+#if defined(MBEDTLS_MEMORY_DEBUG)
+    size_t          alloc_count;
+    size_t          free_count;
+    size_t          total_used;
+    size_t          maximum_used;
+    size_t          header_count;
+    size_t          maximum_header_count;
+#endif
+#if defined(MBEDTLS_THREADING_C)
+    mbedtls_threading_mutex_t   mutex;
+#endif
+}
+buffer_alloc_ctx;
+
+static buffer_alloc_ctx heap;
+
+#if defined(MBEDTLS_MEMORY_DEBUG)
+static void debug_header(memory_header *hdr)
+{
+#if defined(MBEDTLS_MEMORY_BACKTRACE)
+    size_t i;
+#endif
+
+    mbedtls_fprintf(stderr, "HDR:  PTR(%10zu), PREV(%10zu), NEXT(%10zu), "
+                            "ALLOC(%zu), SIZE(%10zu)\n",
+                    (size_t) hdr, (size_t) hdr->prev, (size_t) hdr->next,
+                    hdr->alloc, hdr->size);
+    mbedtls_fprintf(stderr, "      FPREV(%10zu), FNEXT(%10zu)\n",
+                    (size_t) hdr->prev_free, (size_t) hdr->next_free);
+
+#if defined(MBEDTLS_MEMORY_BACKTRACE)
+    mbedtls_fprintf(stderr, "TRACE: \n");
+    for (i = 0; i < hdr->trace_count; i++) {
+        mbedtls_fprintf(stderr, "%s\n", hdr->trace[i]);
+    }
+    mbedtls_fprintf(stderr, "\n");
+#endif
+}
+
+static void debug_chain(void)
+{
+    memory_header *cur = heap.first;
+
+    mbedtls_fprintf(stderr, "\nBlock list\n");
+    while (cur != NULL) {
+        debug_header(cur);
+        cur = cur->next;
+    }
+
+    mbedtls_fprintf(stderr, "Free list\n");
+    cur = heap.first_free;
+
+    while (cur != NULL) {
+        debug_header(cur);
+        cur = cur->next_free;
+    }
+}
+#endif /* MBEDTLS_MEMORY_DEBUG */
+
+static int verify_header(memory_header *hdr)
+{
+    if (hdr->magic1 != MAGIC1) {
+#if defined(MBEDTLS_MEMORY_DEBUG)
+        mbedtls_fprintf(stderr, "FATAL: MAGIC1 mismatch\n");
+#endif
+        return 1;
+    }
+
+    if (hdr->magic2 != MAGIC2) {
+#if defined(MBEDTLS_MEMORY_DEBUG)
+        mbedtls_fprintf(stderr, "FATAL: MAGIC2 mismatch\n");
+#endif
+        return 1;
+    }
+
+    if (hdr->alloc > 1) {
+#if defined(MBEDTLS_MEMORY_DEBUG)
+        mbedtls_fprintf(stderr, "FATAL: alloc has illegal value\n");
+#endif
+        return 1;
+    }
+
+    if (hdr->prev != NULL && hdr->prev == hdr->next) {
+#if defined(MBEDTLS_MEMORY_DEBUG)
+        mbedtls_fprintf(stderr, "FATAL: prev == next\n");
+#endif
+        return 1;
+    }
+
+    if (hdr->prev_free != NULL && hdr->prev_free == hdr->next_free) {
+#if defined(MBEDTLS_MEMORY_DEBUG)
+        mbedtls_fprintf(stderr, "FATAL: prev_free == next_free\n");
+#endif
+        return 1;
+    }
+
+    return 0;
+}
+
+static int verify_chain(void)
+{
+    memory_header *prv = heap.first, *cur;
+
+    if (prv == NULL || verify_header(prv) != 0) {
+#if defined(MBEDTLS_MEMORY_DEBUG)
+        mbedtls_fprintf(stderr, "FATAL: verification of first header "
+                                "failed\n");
+#endif
+        return 1;
+    }
+
+    if (heap.first->prev != NULL) {
+#if defined(MBEDTLS_MEMORY_DEBUG)
+        mbedtls_fprintf(stderr, "FATAL: verification failed: "
+                                "first->prev != NULL\n");
+#endif
+        return 1;
+    }
+
+    cur = heap.first->next;
+
+    while (cur != NULL) {
+        if (verify_header(cur) != 0) {
+#if defined(MBEDTLS_MEMORY_DEBUG)
+            mbedtls_fprintf(stderr, "FATAL: verification of header "
+                                    "failed\n");
+#endif
+            return 1;
+        }
+
+        if (cur->prev != prv) {
+#if defined(MBEDTLS_MEMORY_DEBUG)
+            mbedtls_fprintf(stderr, "FATAL: verification failed: "
+                                    "cur->prev != prv\n");
+#endif
+            return 1;
+        }
+
+        prv = cur;
+        cur = cur->next;
+    }
+
+    return 0;
+}
+
+static void *buffer_alloc_calloc(size_t n, size_t size)
+{
+    memory_header *new, *cur = heap.first_free;
+    unsigned char *p;
+    void *ret;
+    size_t original_len, len;
+#if defined(MBEDTLS_MEMORY_BACKTRACE)
+    void *trace_buffer[MAX_BT];
+    size_t trace_cnt;
+#endif
+
+    if (heap.buf == NULL || heap.first == NULL) {
+        return NULL;
+    }
+
+    original_len = len = n * size;
+
+    if (n == 0 || size == 0 || len / n != size) {
+        return NULL;
+    } else if (len > (size_t) -MBEDTLS_MEMORY_ALIGN_MULTIPLE) {
+        return NULL;
+    }
+
+    if (len % MBEDTLS_MEMORY_ALIGN_MULTIPLE) {
+        len -= len % MBEDTLS_MEMORY_ALIGN_MULTIPLE;
+        len += MBEDTLS_MEMORY_ALIGN_MULTIPLE;
+    }
+
+    // Find block that fits
+    //
+    while (cur != NULL) {
+        if (cur->size >= len) {
+            break;
+        }
+
+        cur = cur->next_free;
+    }
+
+    if (cur == NULL) {
+        return NULL;
+    }
+
+    if (cur->alloc != 0) {
+#if defined(MBEDTLS_MEMORY_DEBUG)
+        mbedtls_fprintf(stderr, "FATAL: block in free_list but allocated "
+                                "data\n");
+#endif
+        mbedtls_exit(1);
+    }
+
+#if defined(MBEDTLS_MEMORY_DEBUG)
+    heap.alloc_count++;
+#endif
+
+    // Found location, split block if > memory_header + 4 room left
+    //
+    if (cur->size - len < sizeof(memory_header) +
+        MBEDTLS_MEMORY_ALIGN_MULTIPLE) {
+        cur->alloc = 1;
+
+        // Remove from free_list
+        //
+        if (cur->prev_free != NULL) {
+            cur->prev_free->next_free = cur->next_free;
+        } else {
+            heap.first_free = cur->next_free;
+        }
+
+        if (cur->next_free != NULL) {
+            cur->next_free->prev_free = cur->prev_free;
+        }
+
+        cur->prev_free = NULL;
+        cur->next_free = NULL;
+
+#if defined(MBEDTLS_MEMORY_DEBUG)
+        heap.total_used += cur->size;
+        if (heap.total_used > heap.maximum_used) {
+            heap.maximum_used = heap.total_used;
+        }
+#endif
+#if defined(MBEDTLS_MEMORY_BACKTRACE)
+        trace_cnt = backtrace(trace_buffer, MAX_BT);
+        cur->trace = backtrace_symbols(trace_buffer, trace_cnt);
+        cur->trace_count = trace_cnt;
+#endif
+
+        if ((heap.verify & MBEDTLS_MEMORY_VERIFY_ALLOC) && verify_chain() != 0) {
+            mbedtls_exit(1);
+        }
+
+        ret = (unsigned char *) cur + sizeof(memory_header);
+        memset(ret, 0, original_len);
+
+        return ret;
+    }
+
+    p = ((unsigned char *) cur) + sizeof(memory_header) + len;
+    /* Double casting is required to prevent compilation warning on Clang-based
+     * compilers when "-Wcast-align" is used. */
+    new = (memory_header *) (void *) p;
+
+    new->size = cur->size - len - sizeof(memory_header);
+    new->alloc = 0;
+    new->prev = cur;
+    new->next = cur->next;
+#if defined(MBEDTLS_MEMORY_BACKTRACE)
+    new->trace = NULL;
+    new->trace_count = 0;
+#endif
+    new->magic1 = MAGIC1;
+    new->magic2 = MAGIC2;
+
+    if (new->next != NULL) {
+        new->next->prev = new;
+    }
+
+    // Replace cur with new in free_list
+    //
+    new->prev_free = cur->prev_free;
+    new->next_free = cur->next_free;
+    if (new->prev_free != NULL) {
+        new->prev_free->next_free = new;
+    } else {
+        heap.first_free = new;
+    }
+
+    if (new->next_free != NULL) {
+        new->next_free->prev_free = new;
+    }
+
+    cur->alloc = 1;
+    cur->size = len;
+    cur->next = new;
+    cur->prev_free = NULL;
+    cur->next_free = NULL;
+
+#if defined(MBEDTLS_MEMORY_DEBUG)
+    heap.header_count++;
+    if (heap.header_count > heap.maximum_header_count) {
+        heap.maximum_header_count = heap.header_count;
+    }
+    heap.total_used += cur->size;
+    if (heap.total_used > heap.maximum_used) {
+        heap.maximum_used = heap.total_used;
+    }
+#endif
+#if defined(MBEDTLS_MEMORY_BACKTRACE)
+    trace_cnt = backtrace(trace_buffer, MAX_BT);
+    cur->trace = backtrace_symbols(trace_buffer, trace_cnt);
+    cur->trace_count = trace_cnt;
+#endif
+
+    if ((heap.verify & MBEDTLS_MEMORY_VERIFY_ALLOC) && verify_chain() != 0) {
+        mbedtls_exit(1);
+    }
+
+    ret = (unsigned char *) cur + sizeof(memory_header);
+    memset(ret, 0, original_len);
+
+    return ret;
+}
+
+static void buffer_alloc_free(void *ptr)
+{
+    memory_header *hdr, *old = NULL;
+    unsigned char *p = (unsigned char *) ptr;
+
+    if (ptr == NULL || heap.buf == NULL || heap.first == NULL) {
+        return;
+    }
+
+    if (p < heap.buf || p >= heap.buf + heap.len) {
+#if defined(MBEDTLS_MEMORY_DEBUG)
+        mbedtls_fprintf(stderr, "FATAL: mbedtls_free() outside of managed "
+                                "space\n");
+#endif
+        mbedtls_exit(1);
+    }
+
+    p -= sizeof(memory_header);
+    /* Double casting is required to prevent compilation warning on Clang-based
+     * compilers when "-Wcast-align" is used. */
+    hdr = (memory_header *) (void *) p;
+
+    if (verify_header(hdr) != 0) {
+        mbedtls_exit(1);
+    }
+
+    if (hdr->alloc != 1) {
+#if defined(MBEDTLS_MEMORY_DEBUG)
+        mbedtls_fprintf(stderr, "FATAL: mbedtls_free() on unallocated "
+                                "data\n");
+#endif
+        mbedtls_exit(1);
+    }
+
+    hdr->alloc = 0;
+
+#if defined(MBEDTLS_MEMORY_DEBUG)
+    heap.free_count++;
+    heap.total_used -= hdr->size;
+#endif
+
+#if defined(MBEDTLS_MEMORY_BACKTRACE)
+    free(hdr->trace);
+    hdr->trace = NULL;
+    hdr->trace_count = 0;
+#endif
+
+    // Regroup with block before
+    //
+    if (hdr->prev != NULL && hdr->prev->alloc == 0) {
+#if defined(MBEDTLS_MEMORY_DEBUG)
+        heap.header_count--;
+#endif
+        hdr->prev->size += sizeof(memory_header) + hdr->size;
+        hdr->prev->next = hdr->next;
+        old = hdr;
+        hdr = hdr->prev;
+
+        if (hdr->next != NULL) {
+            hdr->next->prev = hdr;
+        }
+
+        memset(old, 0, sizeof(memory_header));
+    }
+
+    // Regroup with block after
+    //
+    if (hdr->next != NULL && hdr->next->alloc == 0) {
+#if defined(MBEDTLS_MEMORY_DEBUG)
+        heap.header_count--;
+#endif
+        hdr->size += sizeof(memory_header) + hdr->next->size;
+        old = hdr->next;
+        hdr->next = hdr->next->next;
+
+        if (hdr->prev_free != NULL || hdr->next_free != NULL) {
+            if (hdr->prev_free != NULL) {
+                hdr->prev_free->next_free = hdr->next_free;
+            } else {
+                heap.first_free = hdr->next_free;
+            }
+
+            if (hdr->next_free != NULL) {
+                hdr->next_free->prev_free = hdr->prev_free;
+            }
+        }
+
+        hdr->prev_free = old->prev_free;
+        hdr->next_free = old->next_free;
+
+        if (hdr->prev_free != NULL) {
+            hdr->prev_free->next_free = hdr;
+        } else {
+            heap.first_free = hdr;
+        }
+
+        if (hdr->next_free != NULL) {
+            hdr->next_free->prev_free = hdr;
+        }
+
+        if (hdr->next != NULL) {
+            hdr->next->prev = hdr;
+        }
+
+        memset(old, 0, sizeof(memory_header));
+    }
+
+    // Prepend to free_list if we have not merged
+    // (Does not have to stay in same order as prev / next list)
+    //
+    if (old == NULL) {
+        hdr->next_free = heap.first_free;
+        if (heap.first_free != NULL) {
+            heap.first_free->prev_free = hdr;
+        }
+        heap.first_free = hdr;
+    }
+
+    if ((heap.verify & MBEDTLS_MEMORY_VERIFY_FREE) && verify_chain() != 0) {
+        mbedtls_exit(1);
+    }
+}
+
+void mbedtls_memory_buffer_set_verify(int verify)
+{
+    heap.verify = verify;
+}
+
+int mbedtls_memory_buffer_alloc_verify(void)
+{
+    return verify_chain();
+}
+
+#if defined(MBEDTLS_MEMORY_DEBUG)
+void mbedtls_memory_buffer_alloc_status(void)
+{
+    mbedtls_fprintf(stderr,
+                    "Current use: %zu blocks / %zu bytes, max: %zu blocks / "
+                    "%zu bytes (total %zu bytes), alloc / free: %zu / %zu\n",
+                    heap.header_count, heap.total_used,
+                    heap.maximum_header_count, heap.maximum_used,
+                    heap.maximum_header_count * sizeof(memory_header)
+                    + heap.maximum_used,
+                    heap.alloc_count, heap.free_count);
+
+    if (heap.first->next == NULL) {
+        mbedtls_fprintf(stderr, "All memory de-allocated in stack buffer\n");
+    } else {
+        mbedtls_fprintf(stderr, "Memory currently allocated:\n");
+        debug_chain();
+    }
+}
+
+void mbedtls_memory_buffer_alloc_count_get(size_t *alloc_count, size_t *free_count)
+{
+    *alloc_count = heap.alloc_count;
+    *free_count = heap.free_count;
+}
+
+void mbedtls_memory_buffer_alloc_max_get(size_t *max_used, size_t *max_blocks)
+{
+    *max_used   = heap.maximum_used;
+    *max_blocks = heap.maximum_header_count;
+}
+
+void mbedtls_memory_buffer_alloc_max_reset(void)
+{
+    heap.maximum_used = 0;
+    heap.maximum_header_count = 0;
+}
+
+void mbedtls_memory_buffer_alloc_cur_get(size_t *cur_used, size_t *cur_blocks)
+{
+    *cur_used   = heap.total_used;
+    *cur_blocks = heap.header_count;
+}
+#endif /* MBEDTLS_MEMORY_DEBUG */
+
+#if defined(MBEDTLS_THREADING_C)
+static void *buffer_alloc_calloc_mutexed(size_t n, size_t size)
+{
+    void *buf;
+    if (mbedtls_mutex_lock(&heap.mutex) != 0) {
+        return NULL;
+    }
+    buf = buffer_alloc_calloc(n, size);
+    if (mbedtls_mutex_unlock(&heap.mutex)) {
+        return NULL;
+    }
+    return buf;
+}
+
+static void buffer_alloc_free_mutexed(void *ptr)
+{
+    /* We have no good option here, but corrupting the heap seems
+     * worse than losing memory. */
+    if (mbedtls_mutex_lock(&heap.mutex)) {
+        return;
+    }
+    buffer_alloc_free(ptr);
+    (void) mbedtls_mutex_unlock(&heap.mutex);
+}
+#endif /* MBEDTLS_THREADING_C */
+
+void mbedtls_memory_buffer_alloc_init(unsigned char *buf, size_t len)
+{
+    memset(&heap, 0, sizeof(buffer_alloc_ctx));
+
+#if defined(MBEDTLS_THREADING_C)
+    mbedtls_mutex_init(&heap.mutex);
+    mbedtls_platform_set_calloc_free(buffer_alloc_calloc_mutexed,
+                                     buffer_alloc_free_mutexed);
+#else
+    mbedtls_platform_set_calloc_free(buffer_alloc_calloc, buffer_alloc_free);
+#endif
+
+    if (len < sizeof(memory_header) + MBEDTLS_MEMORY_ALIGN_MULTIPLE) {
+        return;
+    } else if ((size_t) buf % MBEDTLS_MEMORY_ALIGN_MULTIPLE) {
+        /* Adjust len first since buf is used in the computation */
+        len -= MBEDTLS_MEMORY_ALIGN_MULTIPLE
+               - (size_t) buf % MBEDTLS_MEMORY_ALIGN_MULTIPLE;
+        buf += MBEDTLS_MEMORY_ALIGN_MULTIPLE
+               - (size_t) buf % MBEDTLS_MEMORY_ALIGN_MULTIPLE;
+    }
+
+    memset(buf, 0, len);
+
+    heap.buf = buf;
+    heap.len = len;
+
+    /* Double casting is required to prevent compilation warning on Clang-based
+     * compilers when "-Wcast-align" is used. */
+    heap.first = (memory_header *) (void *) buf;
+    heap.first->size = len - sizeof(memory_header);
+    heap.first->magic1 = MAGIC1;
+    heap.first->magic2 = MAGIC2;
+    heap.first_free = heap.first;
+}
+
+void mbedtls_memory_buffer_alloc_free(void)
+{
+#if defined(MBEDTLS_THREADING_C)
+    mbedtls_mutex_free(&heap.mutex);
+#endif
+    mbedtls_platform_zeroize(&heap, sizeof(buffer_alloc_ctx));
+}
+
+#if defined(MBEDTLS_SELF_TEST)
+static int check_pointer(void *p)
+{
+    if (p == NULL) {
+        return -1;
+    }
+
+    if ((size_t) p % MBEDTLS_MEMORY_ALIGN_MULTIPLE != 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static int check_all_free(void)
+{
+    if (
+#if defined(MBEDTLS_MEMORY_DEBUG)
+        heap.total_used != 0 ||
+#endif
+        heap.first != heap.first_free ||
+        (void *) heap.first != (void *) heap.buf) {
+        return -1;
+    }
+
+    return 0;
+}
+
+#define TEST_ASSERT(condition)            \
+    if (!(condition))                     \
+    {                                       \
+        if (verbose != 0)                  \
+        mbedtls_printf("failed\n");  \
+                                            \
+        ret = 1;                            \
+        goto cleanup;                       \
+    }
+
+int mbedtls_memory_buffer_alloc_self_test(int verbose)
+{
+    unsigned char buf[1024];
+    unsigned char *p, *q, *r, *end;
+    int ret = 0;
+
+    if (verbose != 0) {
+        mbedtls_printf("  MBA test #1 (basic alloc-free cycle): ");
+    }
+
+    mbedtls_memory_buffer_alloc_init(buf, sizeof(buf));
+
+    p = mbedtls_calloc(1, 1);
+    q = mbedtls_calloc(1, 128);
+    r = mbedtls_calloc(1, 16);
+
+    TEST_ASSERT(check_pointer(p) == 0 &&
+                check_pointer(q) == 0 &&
+                check_pointer(r) == 0);
+
+    mbedtls_free(r);
+    mbedtls_free(q);
+    mbedtls_free(p);
+
+    TEST_ASSERT(check_all_free() == 0);
+
+    /* Memorize end to compare with the next test */
+    end = heap.buf + heap.len;
+
+    mbedtls_memory_buffer_alloc_free();
+
+    if (verbose != 0) {
+        mbedtls_printf("passed\n");
+    }
+
+    if (verbose != 0) {
+        mbedtls_printf("  MBA test #2 (buf not aligned): ");
+    }
+
+    mbedtls_memory_buffer_alloc_init(buf + 1, sizeof(buf) - 1);
+
+    TEST_ASSERT(heap.buf + heap.len == end);
+
+    p = mbedtls_calloc(1, 1);
+    q = mbedtls_calloc(1, 128);
+    r = mbedtls_calloc(1, 16);
+
+    TEST_ASSERT(check_pointer(p) == 0 &&
+                check_pointer(q) == 0 &&
+                check_pointer(r) == 0);
+
+    mbedtls_free(r);
+    mbedtls_free(q);
+    mbedtls_free(p);
+
+    TEST_ASSERT(check_all_free() == 0);
+
+    mbedtls_memory_buffer_alloc_free();
+
+    if (verbose != 0) {
+        mbedtls_printf("passed\n");
+    }
+
+    if (verbose != 0) {
+        mbedtls_printf("  MBA test #3 (full): ");
+    }
+
+    mbedtls_memory_buffer_alloc_init(buf, sizeof(buf));
+
+    p = mbedtls_calloc(1, sizeof(buf) - sizeof(memory_header));
+
+    TEST_ASSERT(check_pointer(p) == 0);
+    TEST_ASSERT(mbedtls_calloc(1, 1) == NULL);
+
+    mbedtls_free(p);
+
+    p = mbedtls_calloc(1, sizeof(buf) - 2 * sizeof(memory_header) - 16);
+    q = mbedtls_calloc(1, 16);
+
+    TEST_ASSERT(check_pointer(p) == 0 && check_pointer(q) == 0);
+    TEST_ASSERT(mbedtls_calloc(1, 1) == NULL);
+
+    mbedtls_free(q);
+
+    TEST_ASSERT(mbedtls_calloc(1, 17) == NULL);
+
+    mbedtls_free(p);
+
+    TEST_ASSERT(check_all_free() == 0);
+
+    mbedtls_memory_buffer_alloc_free();
+
+    if (verbose != 0) {
+        mbedtls_printf("passed\n");
+    }
+
+cleanup:
+    mbedtls_memory_buffer_alloc_free();
+
+    return ret;
+}
+#endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_MEMORY_BUFFER_ALLOC_C */

--- a/platform/memory_buffer_alloc.c
+++ b/platform/memory_buffer_alloc.c
@@ -60,12 +60,16 @@ typedef struct {
     size_t          maximum_header_count;
 #endif
 #if defined(MBEDTLS_THREADING_C)
-    mbedtls_threading_mutex_t   mutex;
+    mbedtls_threading_mutex_t   *mutex;
 #endif
 }
 buffer_alloc_ctx;
 
 static buffer_alloc_ctx heap;
+
+#if defined(MBEDTLS_THREADING_C)
+extern mbedtls_threading_mutex_t mbedtls_threading_heap_mutex;
+#endif
 
 #if defined(MBEDTLS_MEMORY_DEBUG)
 static void debug_header(memory_header *hdr)
@@ -541,11 +545,11 @@ void mbedtls_memory_buffer_alloc_cur_get(size_t *cur_used, size_t *cur_blocks)
 static void *buffer_alloc_calloc_mutexed(size_t n, size_t size)
 {
     void *buf;
-    if (mbedtls_mutex_lock(&heap.mutex) != 0) {
+    if (mbedtls_mutex_lock(heap.mutex) != 0) {
         return NULL;
     }
     buf = buffer_alloc_calloc(n, size);
-    if (mbedtls_mutex_unlock(&heap.mutex)) {
+    if (mbedtls_mutex_unlock(heap.mutex)) {
         return NULL;
     }
     return buf;
@@ -555,11 +559,11 @@ static void buffer_alloc_free_mutexed(void *ptr)
 {
     /* We have no good option here, but corrupting the heap seems
      * worse than losing memory. */
-    if (mbedtls_mutex_lock(&heap.mutex)) {
+    if (mbedtls_mutex_lock(heap.mutex)) {
         return;
     }
     buffer_alloc_free(ptr);
-    (void) mbedtls_mutex_unlock(&heap.mutex);
+    (void) mbedtls_mutex_unlock(heap.mutex);
 }
 #endif /* MBEDTLS_THREADING_C */
 
@@ -568,7 +572,9 @@ void mbedtls_memory_buffer_alloc_init(unsigned char *buf, size_t len)
     memset(&heap, 0, sizeof(buffer_alloc_ctx));
 
 #if defined(MBEDTLS_THREADING_C)
-    mbedtls_mutex_init(&heap.mutex);
+    heap.mutex = &mbedtls_threading_heap_mutex;
+
+    mbedtls_mutex_init(heap.mutex);
     mbedtls_platform_set_calloc_free(buffer_alloc_calloc_mutexed,
                                      buffer_alloc_free_mutexed);
 #else
@@ -602,7 +608,7 @@ void mbedtls_memory_buffer_alloc_init(unsigned char *buf, size_t len)
 void mbedtls_memory_buffer_alloc_free(void)
 {
 #if defined(MBEDTLS_THREADING_C)
-    mbedtls_mutex_free(&heap.mutex);
+    mbedtls_mutex_free(heap.mutex);
 #endif
     mbedtls_platform_zeroize(&heap, sizeof(buffer_alloc_ctx));
 }

--- a/platform/platform.c
+++ b/platform/platform.c
@@ -41,8 +41,8 @@ static void platform_free_uninit(void *ptr)
 #define MBEDTLS_PLATFORM_STD_FREE     platform_free_uninit
 #endif /* !MBEDTLS_PLATFORM_STD_FREE */
 
-static void * (*mbedtls_calloc_func)(size_t, size_t) = MBEDTLS_PLATFORM_STD_CALLOC;
-static void (*mbedtls_free_func)(void *) = MBEDTLS_PLATFORM_STD_FREE;
+void * (*mbedtls_calloc_func)(size_t, size_t) = MBEDTLS_PLATFORM_STD_CALLOC;
+void (*mbedtls_free_func)(void *) = MBEDTLS_PLATFORM_STD_FREE;
 
 void *mbedtls_calloc(size_t nmemb, size_t size)
 {

--- a/platform/platform_util.c
+++ b/platform/platform_util.c
@@ -88,7 +88,7 @@
 #if !defined(MBEDTLS_PLATFORM_HAS_EXPLICIT_BZERO) && !(defined(__STDC_LIB_EXT1__) && \
     !defined(__IAR_SYSTEMS_ICC__)) \
     && !defined(_WIN32)
-static void *(*const volatile memset_func)(void *, int, size_t) = memset;
+void *(*const volatile memset_func)(void *, int, size_t) = memset;
 #endif
 
 void mbedtls_platform_zeroize(void *buf, size_t len)

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,1 @@
+name: oberon-psa-crypto


### PR DESCRIPTION
Left out (from `sdk-mbedtls`):
- [[nrf noup] Check if GCM_C is defined in gcm.h](https://github.com/nrfconnect/sdk-mbedtls/commit/f255713cc9ea4cb37b13a00355c1b632692efe70/)
- [[nrf noup] enable PSA_UTIL_HAVE_ECDSA also when ECDSA_C](https://github.com/nrfconnect/sdk-mbedtls/commit/2a717394431316b565ad70c6757c3c3bea7ed092/)
- [[nrf noup] include md.h in psa_util.h](https://github.com/nrfconnect/sdk-mbedtls/commit/60f240243e5a30d5a706500f5785674350ae8b38/)
- [[nrf noup]: Allow for using legacy when MBEDTLS_FORCE_LEGACY_MD/CIPHER](https://github.com/nrfconnect/sdk-mbedtls/commit/cd57352dc725cb0a841bee443badf8f72a7e1c02/)