### PR TITLE
[nrf noup] Add PSA_ALG_IS_SP800_108_COUNTER_CMAC macro

### DIFF
--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -541,6 +541,11 @@ static int psa_key_algorithm_permits(psa_key_type_t key_type,
                    requested_output_length;
         }
     }
+
+    if (policy_alg == PSA_ALG_CMAC && requested_alg == PSA_ALG_SP800_108_COUNTER_CMAC) {
+        return 1;
+    }
+
     /* If policy_alg is a generic key agreement operation, then using it for
      * a key derivation with that key agreement should also be allowed. This
      * behaviour is expected to be defined in a future specification version. */

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -2301,6 +2301,18 @@
  */
 #define PSA_ALG_SP800_108_COUNTER_CMAC          ((psa_algorithm_t) 0x08000800)
 
+/** Whether the specified algorithm is a key derivation algorithm constructed
+ * using #PSA_ALG_SP800_108_COUNTER_CMAC.
+ *
+ * \param alg An algorithm identifier (value of type #psa_algorithm_t).
+ *
+ * \return 1 if \p alg is a key derivation algorithm constructed using #PSA_ALG_SP800_108_COUNTER_CMAC(),
+ *         0 otherwise. This macro may return either 0 or 1 if \c alg is not a supported
+ *         key derivation algorithm identifier.
+ */
+#define PSA_ALG_IS_SP800_108_COUNTER_CMAC(alg)                         \
+    ((alg) == PSA_ALG_SP800_108_COUNTER_CMAC)
+
 #define PSA_ALG_SRP_PASSWORD_HASH_BASE          ((psa_algorithm_t) 0x08800300)
 /** The SRP password to password-hash KDF.
  * It takes the password p, the salt s, and the user id u.


### PR DESCRIPTION
This macro is used by the TF-M tests and is implemented as a patch in the TF-M patch files for TF-PSA-Crypto.

Since Oberon PSA crypto acts as TF-PSA-Crypto provider add this here.

This will be communicated to Oberon so that we can drop this noup.